### PR TITLE
Optimize PNGS images

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+dependencies:
+    pre:
+      - apt-get install pngquant
+
 test:
   pre:
     # your fork of the docs repo is probably not called "docs"
@@ -15,6 +19,7 @@ deployment:
     branch: master
     owner: opendatakit
     commands:
+      - pngquant $HOME/docs/build/_images/*.png
       - aws s3 sync $HOME/docs/build s3://$S3_BUCKET --delete --exclude "*" --include "*.html" --include "*.js" --include "_sources/*" --include "_images/*" --include "_static/*"
       - aws configure set preview.cloudfront true
       - aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "/*"

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 dependencies:
     pre:
-      - apt-get install pngquant
+      - sudo apt-get install pngquant
 
 test:
   pre:


### PR DESCRIPTION
Closes #64 

I verified this works by SSHing into the build machine and running the various commands.

The risk I see with merging this PR is that pngquant is by default not verbose, so if the compression takes longer than 10 minutes with no output, CirceCI will terminate the build. 

We can fix this by adding -v to the png command or increasing the timeouts on the command, but I'd like to see how this PR behaves first.