### PR TITLE
Overwrite source images when publishing

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ deployment:
     branch: master
     owner: opendatakit
     commands:
-      - pngquant $HOME/docs/build/_images/*.png
+      - pngquant $HOME/docs/build/_images/*.png  --strip --verbose --force --ext .png
       - aws s3 sync $HOME/docs/build s3://$S3_BUCKET --delete --exclude "*" --include "*.html" --include "*.js" --include "_sources/*" --include "_images/*" --include "_static/*"
       - aws configure set preview.cloudfront true
       - aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "/*"


### PR DESCRIPTION
I assumed that the existing circle.yml file overwrites the source images. It doesn't, and this command implements the behavior I wanted.