### PR TITLE
Warnings as errors

### DIFF
--- a/b.sh
+++ b/b.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 rm -rf build/*
-sphinx-build -b dirhtml . build
+sphinx-build -W -b dirhtml . build

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ test:
     - cd $HOME/docs && git lfs pull
 
   override:
-    - sphinx-build -b dirhtml $HOME/docs $HOME/docs/build
+    - sphinx-build -W -b dirhtml $HOME/docs $HOME/docs/build
 
   post:
     - cp -r $HOME/docs/build $CIRCLE_ARTIFACTS


### PR DESCRIPTION
Closes #80 

The `-W` flag turns warnings into errors. I've confirmed this shows an error by temporarily breaking an image link.