### PR TITLE
Added a separate document for adb

### DIFF
--- a/collect-adb.rst
+++ b/collect-adb.rst
@@ -1,0 +1,86 @@
+*****************************************
+Using Android Debug Bridge with Collect
+*****************************************
+
+This document focuses specifically on using **adb** as a command line tool to perform a variety of tasks related to Collect. 
+
+.. _what-is-it:
+
+What is Android Debug Bridge (adb)?
+====================================
+
+Android Debug Bridge or `adb <https://developer.android.com/studio/command-line/adb.html>`_ is a command line tool which, as the name suggests, acts as a bridge between the Android device and the terminal. It can control your device over USB from a computer, copy files back and forth, install and uninstall apps, run shell commands, and more. For the developers of ODK Collect, the most common ones include pushing blank forms to SD Card, pulling the form database, deleting forms, making the **.apk** file from the source code, etc. To install **adb**, please follow the instructions given `here <https://android.gadgethacks.com/how-to/android-basics-install-adb-fastboot-mac-linux-windows-0164225/>`_.
+
+.. _downloading-adb:
+
+Downloading adb
+================
+
+If you're already working on Android studio, you'll have **adb** already installed with it, but it requires specific configurations. To use adb with a device connected over USB, you must enable USB debugging in the device system settings, under Developer options. On Android 4.2 and higher, the Developer options screen is hidden by default. To make it visible, go to ``Settings``, then ``About phone`` and tap ``Build number`` seven times. Return to the previous screen to find Developer options at the bottom.
+
+For people who don't have Android studio installed, **adb** can be downloaded as a standalone tool, either through command line or from the official Android Studio's `Command line tools page <https://developer.android.com/studio/index.html#command-tools>`_.
+
+.. _using-adb:
+
+Using adb with Collect
+=======================
+
+As mentioned before in the `Form Management section <https://docs.opendatakit.org/collect-forms/>`_, forms can be manipulated pretty easily from the command line itself. The following points describe how **adb** can be used to work with the app:
+
+Loading blank forms
+~~~~~~~~~~~~~~~~~~~~
+
+All the data related to form instances and other files are saved in :guilabel:`sdcard/odk/forms/` folder on the device. Hence if can easily download a form from external sources and transfer them to the device via USB cable. To do this, just run:
+
+.. code-block:: none
+
+  $ adb push path/to/form.xml /sdcard/odk/forms/form.xml
+
+While filling the form, it is possible to copy the contents of one form into another eaisly, just by knowing the path of the form.
+
+.. code-block:: none
+
+  $ adb shell cp /sdcard/odk/forms/form-1.xml /sdcard/odk/forms/form-2.xml
+
+.. note::
+
+  Copying the contents of the form doesn't copy the current state (saved, sent or finalized) of the form. 
+
+Deleting forms
+~~~~~~~~~~~~~~~
+
+You can delete form instances directly with :command:`adb`. They are stored in :file:`sdcard/odk/forms`, with a directory for each instance. You can do so by using the command:
+
+.. code-block:: none
+
+  $ adb shell rm -d /sdcard/odk/forms/my_form.xml
+
+Downloading forms to your computer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can download a specified form from the emulator/device to your computer using the **adb** tool. Developers might also need to check the entries in the database from the computer. In such case we can simple pull the database file from the SD card and use any database visualizer to see the data. For getting a form, simply run:
+
+.. code-block:: none
+
+  $ adb pull /sdcard/odk/forms/my_form.xml
+
+.. _saving-screenshot:
+
+Saving screenshot
+~~~~~~~~~~~~~~~~~~
+
+Document writers need to take screenshots of the running app to help the readers visualize and verify everything. While using an emulator or a device, this might take some time. For this purpose, **adb** also provides a feature call **screencap** which can take a screenshot and upload it to your computer. For taking a screenshot, just run:
+
+.. code-block:: none
+
+  $ adb shell screencap /sdcard/screen.png
+
+Here, the image will be stored as ``screen.png`` which can be downloaded to the computer by running:
+
+.. code-block:: none
+
+  $ adb pull /sdcard/screen.png
+
+
+
+

--- a/collect-adb.rst
+++ b/collect-adb.rst
@@ -8,7 +8,7 @@ Using Android Debug Bridge with Collect
 - fetching completed forms
 - deleting forms
 - copying the form database
-- making the **.apk** file from the source code
+- installing the **.apk** file from the source code
 
 .. _install-adb:
 

--- a/collect-adb.rst
+++ b/collect-adb.rst
@@ -69,8 +69,6 @@ Developers might also need to check the entries in the database from the compute
   
   $  adb -pull /sdcard/odk/database/database.name
 
-Here *target* refers to the location where the database is stored on computer.
-
 .. _saving-screenshot-with-adb:
 
 Saving screenshot

--- a/collect-adb.rst
+++ b/collect-adb.rst
@@ -2,13 +2,6 @@
 Using Android Debug Bridge with Collect
 *****************************************
 
-This document focuses specifically on using :command:`adb` as a command line tool to perform tasks related to Collect. 
-
-.. _what-is-adb:
-
-What is Android Debug Bridge (adb)?
-====================================
-
 `Android Debug Bridge <https://developer.android.com/studio/command-line/adb.html>`_ is a command which acts as a bridge between the Android device and the terminal. It can control device over USB from a computer, copy files back and forth, install and uninstall apps, run shell commands etc. For the developers and users of ODK Collect, the most common uses are:
 
 - loading blank forms to SD Card

--- a/collect-adb.rst
+++ b/collect-adb.rst
@@ -4,39 +4,36 @@ Using Android Debug Bridge with Collect
 
 This document focuses specifically on using **adb** as a command line tool to perform a variety of tasks related to Collect. 
 
-.. _what-is-it:
+.. _what-is-adb:
 
 What is Android Debug Bridge (adb)?
 ====================================
 
-Android Debug Bridge or `adb <https://developer.android.com/studio/command-line/adb.html>`_ is a command line tool which, as the name suggests, acts as a bridge between the Android device and the terminal. It can control your device over USB from a computer, copy files back and forth, install and uninstall apps, run shell commands, and more. For the developers of ODK Collect, the most common ones include pushing blank forms to SD Card, pulling the form database, deleting forms, making the **.apk** file from the source code, etc. To install **adb**, please follow the instructions given `here <https://android.gadgethacks.com/how-to/android-basics-install-adb-fastboot-mac-linux-windows-0164225/>`_.
+Android Debug Bridge or `adb <https://developer.android.com/studio/command-line/adb.html>`_ is a command line tool which, as the name suggests, acts as a bridge between the Android device and the terminal. It can control your device over USB from a computer, copy files back and forth, install and uninstall apps, run shell commands, and more. To install **adb**, please follow the instructions given `here <https://android.gadgethacks.com/how-to/android-basics-install-adb-fastboot-mac-linux-windows-0164225/>`_. For the developers and users of ODK Collect, the most common uses are:
 
-.. _downloading-adb:
+- include pushing blank forms to SD Card
+- pulling the form database, deleting forms
+- making the **.apk** file from the source code
 
-Downloading adb
-================
-
-If you're already working on Android studio, you'll have **adb** already installed with it, but it requires specific configurations. To use adb with a device connected over USB, you must enable USB debugging in the device system settings, under Developer options. On Android 4.2 and higher, the Developer options screen is hidden by default. To make it visible, go to ``Settings``, then ``About phone`` and tap ``Build number`` seven times. Return to the previous screen to find Developer options at the bottom.
-
-For people who don't have Android studio installed, **adb** can be downloaded as a standalone tool, either through command line or from the official Android Studio's `Command line tools page <https://developer.android.com/studio/index.html#command-tools>`_.
-
-.. _using-adb:
+.. _using-adb-with-collect:
 
 Using adb with Collect
 =======================
 
-As mentioned before in the `Form Management section <https://docs.opendatakit.org/collect-forms/>`_, forms can be manipulated pretty easily from the command line itself. The following points describe how **adb** can be used to work with the app:
+As mentioned before in the `Form Management section <https://docs.opendatakit.org/collect-forms/>`_, forms can be manipulated pretty easily from the command line itself. The following points describe how **adb** can be used to work with the app.
+
+.. _loading-blank-forms-with-adb:
 
 Loading blank forms
 ~~~~~~~~~~~~~~~~~~~~
 
-All the data related to form instances and other files are saved in :guilabel:`sdcard/odk/forms/` folder on the device. Hence if can easily download a form from external sources and transfer them to the device via USB cable. To do this, just run:
+The forms are stored in :guilabel:`sdcard/odk/forms/` folder on the device. They can be downloaded from external source and loaded via a USB device using:
 
 .. code-block:: none
 
   $ adb push path/to/form.xml /sdcard/odk/forms/form.xml
 
-While filling the form, it is possible to copy the contents of one form into another eaisly, just by knowing the path of the form.
+Contents of a form can be copied using:
 
 .. code-block:: none
 
@@ -46,25 +43,42 @@ While filling the form, it is possible to copy the contents of one form into ano
 
   Copying the contents of the form doesn't copy the current state (saved, sent or finalized) of the form. 
 
+.. _deleting-forms-with-adb:
+
 Deleting forms
 ~~~~~~~~~~~~~~~
 
-You can delete form instances directly with :command:`adb`. They are stored in :file:`sdcard/odk/forms`, with a directory for each instance. You can do so by using the command:
+You can delete form instances with :command:`adb`. They are stored in :file:`sdcard/odk/forms`, with a directory for each instance. You can do so by using the command:
 
 .. code-block:: none
 
   $ adb shell rm -d /sdcard/odk/forms/my_form.xml
 
+.. _downloading-forms:
+
 Downloading forms to your computer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can download a specified form from the emulator/device to your computer using the **adb** tool. Developers might also need to check the entries in the database from the computer. In such case we can simple pull the database file from the SD card and use any database visualizer to see the data. For getting a form, simply run:
+You can download a specified form from the device to your computer using the **adb** tool.
 
 .. code-block:: none
 
   $ adb pull /sdcard/odk/forms/my_form.xml
 
-.. _saving-screenshot:
+.. _downloading-database-with-adb:
+
+Downloading database
+~~~~~~~~~~~~~~~~~~~~~~
+
+Developers might also need to check the entries in the database from the computer. In such cases pull the database file from the SD card and use any **SQLite visualizer** to see the data. To pull the database into the computer, run:
+
+.. code-block:: none
+  
+  $  adb -d shell "run-as org.odk.collect.android cat databases/database.name" > target.sqlite
+
+Here *target* refers to the location where the database is stored on computer.
+
+.. _saving-screenshot-with-adb:
 
 Saving screenshot
 ~~~~~~~~~~~~~~~~~~
@@ -73,13 +87,17 @@ Document writers need to take screenshots of the running app to help the readers
 
 .. code-block:: none
 
-  $ adb shell screencap /sdcard/screen.png
+  $ adb exec-out screencap /sdcard/screen.png
 
 Here, the image will be stored as ``screen.png`` which can be downloaded to the computer by running:
 
 .. code-block:: none
 
   $ adb pull /sdcard/screen.png
+
+.. note::
+
+  You can also use Collect's program to get a screenshot by referring to the instructions given in the `Contribution Guide <https://docs.opendatakit.org/contributing/#screenshots-from-odk-collect>`_.
 
 
 

--- a/collect-adb.rst
+++ b/collect-adb.rst
@@ -2,14 +2,14 @@
 Using Android Debug Bridge with Collect
 *****************************************
 
-This document focuses specifically on using **adb** as a command line tool to perform a variety of tasks related to Collect. 
+This document focuses specifically on using **adb** as a command line tool to perform tasks related to Collect. 
 
 .. _what-is-adb:
 
 What is Android Debug Bridge (adb)?
 ====================================
 
-Android Debug Bridge or `adb <https://developer.android.com/studio/command-line/adb.html>`_ is a command line tool which, as the name suggests, acts as a bridge between the Android device and the terminal. It can control your device over USB from a computer, copy files back and forth, install and uninstall apps, run shell commands, and more. To install **adb**, please follow the instructions given `here <https://android.gadgethacks.com/how-to/android-basics-install-adb-fastboot-mac-linux-windows-0164225/>`_. For the developers and users of ODK Collect, the most common uses are:
+Android Debug Bridge or `adb <https://developer.android.com/studio/command-line/adb.html>`_ is a command line tool which acts as a bridge between the Android device and the terminal. It can control device over USB from a computer, copy files back and forth, install and uninstall apps, run shell commands, and more. To install **adb**, please follow the instructions given `here <https://android.gadgethacks.com/how-to/android-basics-install-adb-fastboot-mac-linux-windows-0164225/>`_. For the developers and users of ODK Collect, the most common uses are:
 
 - include pushing blank forms to SD Card
 - pulling the form database, deleting forms
@@ -20,7 +20,7 @@ Android Debug Bridge or `adb <https://developer.android.com/studio/command-line/
 Using adb with Collect
 =======================
 
-As mentioned before in the `Form Management section <https://docs.opendatakit.org/collect-forms/>`_, forms can be manipulated pretty easily from the command line itself. The following points describe how **adb** can be used to work with the app.
+Forms can be manipulated from the command line itself. The following sections describe how **adb** can be used to work with the app.
 
 .. _loading-blank-forms-with-adb:
 
@@ -33,7 +33,7 @@ The forms are stored in :guilabel:`sdcard/odk/forms/` folder on the device. They
 
   $ adb push path/to/form.xml /sdcard/odk/forms/form.xml
 
-Contents of a form can be copied using:
+Contents of a form can be copied by running:
 
 .. code-block:: none
 
@@ -41,14 +41,14 @@ Contents of a form can be copied using:
 
 .. note::
 
-  Copying the contents of the form doesn't copy the current state (saved, sent or finalized) of the form. 
+  Copying the contents of the form doesn't copy the current state of the form. 
 
 .. _deleting-forms-with-adb:
 
 Deleting forms
 ~~~~~~~~~~~~~~~
 
-You can delete form instances with :command:`adb`. They are stored in :file:`sdcard/odk/forms`, with a directory for each instance. You can do so by using the command:
+Forms can be deleted from :file:`sdcard/odk/forms` by running:
 
 .. code-block:: none
 
@@ -59,7 +59,7 @@ You can delete form instances with :command:`adb`. They are stored in :file:`sdc
 Downloading forms to your computer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can download a specified form from the device to your computer using the **adb** tool.
+To download a specific form from the computer, run:
 
 .. code-block:: none
 
@@ -70,7 +70,7 @@ You can download a specified form from the device to your computer using the **a
 Downloading database
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Developers might also need to check the entries in the database from the computer. In such cases pull the database file from the SD card and use any **SQLite visualizer** to see the data. To pull the database into the computer, run:
+Developers might also need to check the entries in the database from the computer. In such case pull the database file from the SD card and use any **SQLite visualizer** to view it. To pull the database into the computer, run:
 
 .. code-block:: none
   
@@ -83,7 +83,7 @@ Here *target* refers to the location where the database is stored on computer.
 Saving screenshot
 ~~~~~~~~~~~~~~~~~~
 
-Document writers need to take screenshots of the running app to help the readers visualize and verify everything. While using an emulator or a device, this might take some time. For this purpose, **adb** also provides a feature call **screencap** which can take a screenshot and upload it to your computer. For taking a screenshot, just run:
+Document writers need to take screenshots of the running app to help the readers visualize and verify everything. While using an emulator or a device, this might take some time. For this purpose, **adb** also provides a feature call **screencap** which can take a screenshot and upload it to your computer. For taking a screenshot, run:
 
 .. code-block:: none
 

--- a/collect-adb.rst
+++ b/collect-adb.rst
@@ -99,6 +99,17 @@ Here, the image will be stored as ``screen.png`` which can be downloaded to the 
 
   You can also use Collect's program to get a screenshot by referring to the instructions given in the `Contribution Guide <https://docs.opendatakit.org/contributing/#screenshots-from-odk-collect>`_.
 
+.. _recording-video-with-adb:
 
+Recording a video
+~~~~~~~~~~~~~~~~~~~
+
+**adb** can be used to record video on device's screen. This can be done by running:
+
+.. code-block:: none
+
+  $ adb shell screenrecord /sdcard/example.mp4
+
+This command will start recording your device’s screen using the default settings and save the resulting video to a file at :guilabel:`/sdcard/example.mp4` file on your device.
 
 

--- a/collect-adb.rst
+++ b/collect-adb.rst
@@ -13,7 +13,7 @@ Using Android Debug Bridge with Collect
 .. _install-adb:
 
 Installing adb
-===============
+~~~~~~~~~~~~~~~
 
 If you plan to work on ODK Collect or run the app using an emulator, download the `Android Studio <https://developer.android.com/studio/index.html>`_. It already comes with the adb tool. To use it, `enable USB Debugging <https://www.howtogeek.com/125769/how-to-install-and-use-abd-the-android-debug-bridge-utility/>`_.
 

--- a/collect-adb.rst
+++ b/collect-adb.rst
@@ -2,46 +2,46 @@
 Using Android Debug Bridge with Collect
 *****************************************
 
-This document focuses specifically on using **adb** as a command line tool to perform tasks related to Collect. 
+This document focuses specifically on using :command:`adb` as a command line tool to perform tasks related to Collect. 
 
 .. _what-is-adb:
 
 What is Android Debug Bridge (adb)?
 ====================================
 
-Android Debug Bridge or `adb <https://developer.android.com/studio/command-line/adb.html>`_ is a command line tool which acts as a bridge between the Android device and the terminal. It can control device over USB from a computer, copy files back and forth, install and uninstall apps, run shell commands, and more. To install **adb**, please follow the instructions given `here <https://android.gadgethacks.com/how-to/android-basics-install-adb-fastboot-mac-linux-windows-0164225/>`_. For the developers and users of ODK Collect, the most common uses are:
+`Android Debug Bridge <https://developer.android.com/studio/command-line/adb.html>`_ is a command which acts as a bridge between the Android device and the terminal. It can control device over USB from a computer, copy files back and forth, install and uninstall apps, run shell commands etc. For the developers and users of ODK Collect, the most common uses are:
 
-- include pushing blank forms to SD Card
-- pulling the form database, deleting forms
+- loading blank forms to SD Card
+- fetching completed forms
+- deleting forms
+- copying the form database
 - making the **.apk** file from the source code
 
-.. _using-adb-with-collect:
+.. _install-adb:
 
-Using adb with Collect
-=======================
+Installing adb
+===============
 
-Forms can be manipulated from the command line itself. The following sections describe how **adb** can be used to work with the app.
+If you plan to work on ODK Collect or run the app using an emulator, download the `Android Studio <https://developer.android.com/studio/index.html>`_. It already comes with the adb tool. To use it, `enable USB Debugging <https://www.howtogeek.com/125769/how-to-install-and-use-abd-the-android-debug-bridge-utility/>`_.
+
+To install :command:`adb` as a standalone tool, please follow the instructions given `here <https://android.gadgethacks.com/how-to/android-basics-install-adb-fastboot-mac-linux-windows-0164225/>`_.
+
+Forms can be manipulated from the command line itself. The following sections describe how :command:`adb` can be used to work with the app.
 
 .. _loading-blank-forms-with-adb:
 
 Loading blank forms
 ~~~~~~~~~~~~~~~~~~~~
 
-The forms are stored in :guilabel:`sdcard/odk/forms/` folder on the device. They can be downloaded from external source and loaded via a USB device using:
+The forms are stored in :file:`sdcard/odk/forms/` folder on the device. They can be loaded via a USB device using:
 
 .. code-block:: none
 
   $ adb push path/to/form.xml /sdcard/odk/forms/form.xml
 
-Contents of a form can be copied by running:
-
-.. code-block:: none
-
-  $ adb shell cp /sdcard/odk/forms/form-1.xml /sdcard/odk/forms/form-2.xml
-
 .. note::
 
-  Copying the contents of the form doesn't copy the current state of the form. 
+  Path on the phone must include the file name and not just the folder name
 
 .. _deleting-forms-with-adb:
 
@@ -59,7 +59,7 @@ Forms can be deleted from :file:`sdcard/odk/forms` by running:
 Downloading forms to your computer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To download a specific form from the computer, run:
+To download a completed form or form instance from the computer, run:
 
 .. code-block:: none
 
@@ -83,7 +83,7 @@ Here *target* refers to the location where the database is stored on computer.
 Saving screenshot
 ~~~~~~~~~~~~~~~~~~
 
-Document writers need to take screenshots of the running app to help the readers visualize and verify everything. While using an emulator or a device, this might take some time. For this purpose, **adb** also provides a feature call **screencap** which can take a screenshot and upload it to your computer. For taking a screenshot, run:
+For taking a screenshot, run:
 
 .. code-block:: none
 
@@ -97,19 +97,21 @@ Here, the image will be stored as ``screen.png`` which can be downloaded to the 
 
 .. note::
 
-  You can also use Collect's program to get a screenshot by referring to the instructions given in the `Contribution Guide <https://docs.opendatakit.org/contributing/#screenshots-from-odk-collect>`_.
+  You can also use ODK docs program to get a screenshot by referring to the instructions given in the `Contribution Guide <https://docs.opendatakit.org/contributing/#screenshots-from-odk-collect>`_.
 
 .. _recording-video-with-adb:
 
 Recording a video
 ~~~~~~~~~~~~~~~~~~~
 
-**adb** can be used to record video on device's screen. This can be done by running:
+:command:`adb` can be used to record video on device's screen. This can be done by running:
 
 .. code-block:: none
 
   $ adb shell screenrecord /sdcard/example.mp4
 
-This command will start recording your device’s screen using the default settings and save the resulting video to a file at :guilabel:`/sdcard/example.mp4` file on your device.
+As you hit :guilabel:`Enter`, this command will start recording your device’s screen using the default settings and save the resulting video to a file at :guilabel:`/sdcard/example.mp4` file on your device.
+
+To stop the recording, press :guilabel:`ctrl` + :guilabel:`C`
 
 

--- a/collect-adb.rst
+++ b/collect-adb.rst
@@ -74,7 +74,7 @@ Developers might also need to check the entries in the database from the compute
 
 .. code-block:: none
   
-  $  adb -d shell "run-as org.odk.collect.android cat databases/database.name" > target.sqlite
+  $  adb -pull /sdcard/odk/database/database.name
 
 Here *target* refers to the location where the database is stored on computer.
 

--- a/index.rst
+++ b/index.rst
@@ -42,6 +42,7 @@ For a complete list of our projects, check out `Open Data Kit on Github <https:/
   collect-install
   collect-settings
   collect-forms
+  collect-adb
   
 .. toctree::
   :hidden:


### PR DESCRIPTION
Added a new document for using `adb` with Collect. Currently addresses following things:

* What is Android Debug Bridge (adb)?
* Downloading adb
* Using adb with Collect

Still doesn't include possible errors one can face.
Needs more exploring.
Still not referenced anywhere in `collect-forms.rst`