### PR TITLE
 Installation steps of Docs in cygwin

### DIFF
--- a/cygwin.rst
+++ b/cygwin.rst
@@ -1,0 +1,194 @@
+*****************************
+Docs in Windows (Cygwin) 
+*****************************
+
+.. _cygwin-docs:
+
+Cygwin
+-------------------------------
+Cygwin is windows implementation of unix-like commands. You can basically use many linux commands from windows 
+command propmpt.
+
+Install `cygwin <https://cygwin.com/install.html/>`_ and add its path into windows environmental variable.
+This will allow you to `use cygwin from cmd promopt <https://www.howtogeek.com/howto/41382/how-to-use-linux-commands-in-windows-with-cygwin/>`_.
+
+
+.. _python:
+
+Python 3
+-------------------------------
+You need to install `python 3 <https://www.python.org/downloads/>`_.
+During the installation, you can select to set up pip tool as well as add python path to the Path environment variable.
+
+
+
+.. _virtualenv:
+
+Virtual Environment
+-------------------------------
+Virtual environment is a useful tool particularly if you work with multiple projects, each requires different dependencies and python versions. By using virtualenv, you can create seperated virtual environment and install packages as you need without affecting the main 
+python installation.
+
+To install virtualenv in windows, you can basically use pip command, which was already installed with python 3.6.2.
+
+.. code-block:: rest
+
+  $ pip install virtualenv
+
+.. note::
+  You need to make sure you have already installed pip in the previous step.
+
+Create a new directory for your odkdocs work:
+
+.. code-block:: rest
+
+  $ mkdir odk
+    
+You have two options: 
+
+  - Use the native virtualenv.
+  - Use virtualenvwrapper.
+
+
+.. _native-virenv:
+
+Native virtualenv
+~~~~~~~~~~~~~~~~~~~~~
+Create a new python 3 virtual environment, "odkenv" is the name of the virtualenv, you are free to add your own.
+
+.. code-block:: rest
+
+  $ virtualenv --python=<python path/python.exe> odkenv
+ 
+After creating python3 virtualenv in the previous step, multiple files are coppied into the folder odkenv.
+
+.. code-block:: rest
+
+  $ ls odkenv
+
+The folder Scripts contains all virtualenv control as bat files.
+
+To activate the odkenv:
+
+.. code-block:: rest
+
+  $ cd odkenv
+  .
+  .
+  .
+  $ cd Scripts
+
+  $ odk/odkenv/Scripts/activate.bat
+
+
+To deactivate the odkenv:
+
+.. code-block:: rest
+
+  $ odk/odkenv/Scripts/deactivate.bat
+
+.. _virenv-wrapper:
+
+Virtual Environment Wrapper
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Dealing with Virtualenv tool might be tiresome under windows. Thus, you are advised to install virtualenvwrapper tool using the following command.
+
+.. code-block:: rest
+
+  $ pip install virtualenvwrapper-win
+
+
+Create a new virtualenv use the command:
+
+.. code-block:: rest
+
+  $ mkvirtualenv odkenv
+
+Once the odkenv is created, it is autoamtically activated, the current path in cmd will appear for example as:
+
+.. code-block:: rest
+
+  $ (odkenv) C:/odk/docs
+
+To deactivate the odkenv, write:
+
+.. code-block:: rest
+
+  $ deactivate
+
+To activate the odkenv any time:
+
+.. code-block:: rest
+
+  $ workon odkenv
+
+.. _git-glfs:
+
+Git and GLFS
+-------------------------------
+  - Install `Git for windows <https://git-scm.com/downloads>`_.
+
+Make sure that git is installed properly by typing (git) in the cmd.
+
+  - Install `GLFS <https://git-lfs.github.com/>`_.
+
+
+.. _andr-tools:
+
+Android Tools
+-------------------------------
+Android tools (Adb) by installing `Android studio <https://developer.android.com/studio/index.html/>`_
+
+
+.. _fork-clone:
+
+Fork and Clone the docs repo
+-------------------------------
+From github, fork the `odk docs <https://github.com/opendatakit/docs>`_ . this will create a copy od the docs in your account called ``origin``.
+
+Then Clone docs files into your local machine.
+
+.. code-block:: rest
+
+  $ cd odk
+  .
+  .
+  .
+  $ git clone https://github.com/your-github-username/docs.git
+
+
+.. _remote-upstream:
+
+Set the Upstream Remote
+~~~~~~~~~~~~~~~~~~~~~~~~
+.. code-block:: rest
+
+  $ git remote add upstream https://github.com/opendatakit/docs.git
+
+.. _requirs:
+
+Install the requirements
+------------------------
+First activate odkenv:
+
+.. code-block:: rest
+
+  $ workon odkenv
+
+Make sure you are inside the docs folder Then run:
+
+.. code-block:: rest
+ 
+  $ pip install -r requirements.txt
+
+To this step, you will have ODKdocs environment ready. You can start change and build.
+
+Install Notepad++ to edit source files in windows from :
+
+Add `Notepad++ <https://notepad-plus-plus.org/download/v7.5.1.html/>`_ path to the enviroment variable
+
+To edit docs files use: 
+
+.. code-block:: rest 
+
+  $ Notepad++ file.rst

--- a/cygwin.rst
+++ b/cygwin.rst
@@ -1,46 +1,34 @@
 *****************************
-Docs in Windows (Cygwin) 
+Working with Docs in Windows using Cygwin
 *****************************
 
-.. _cygwin-docs:
-
-Cygwin
+Install Cygwin
 -------------------------------
-Cygwin is windows implementation of unix-like commands. You can basically use many linux commands from windows 
-command propmpt.
 
-Install `cygwin <https://cygwin.com/install.html/>`_ and add its path into windows environmental variable.
-This will allow you to `use cygwin from cmd promopt <https://www.howtogeek.com/howto/41382/how-to-use-linux-commands-in-windows-with-cygwin/>`_.
+Cygwin is a Windows implementation of many GNU/Linux commands usable from \*NIX command prompt. Install `cygwin <https://cygwin.com/install.html/>`_ and add its path to Windows, `for instructions <https://www.howtogeek.com/howto/41382/how-to-use-linux-commands-in-windows-with-cygwin/>`_.
 
-
-.. _python:
+.. _cygwin-python:
 
 Python 3
 -------------------------------
-You need to install `python 3 <https://www.python.org/downloads/>`_.
-During the installation, you can select to set up pip tool as well as add python path to the Path environment variable.
 
-
+You need to install `Python 3 <https://www.python.org/downloads/>`_. `For instructions, see <https://www.youtube.com/watch?v=oHOiqFs_x8Y>`_. Make sure to select the option "Add python to the Path", otherwise you need to add it manually.
 
 .. _virtualenv:
 
 Virtual Environment
 -------------------------------
-Virtual environment is a useful tool particularly if you work with multiple projects, each requires different dependencies and python versions. By using virtualenv, you can create seperated virtual environment and install packages as you need without affecting the main 
-python installation.
 
-To install virtualenv in windows, you can basically use pip command, which was already installed with python 3.6.2.
+`A virtual environment tool <https://virtualenv.pypa.io/en/stable/userguide/>`_ creates multiple Pythons, each has its packages and dependencies.
+ To install virtualenv in Windows, you can use pip command, which is already shipped with Python 3.
 
-.. code-block:: rest
+.. code-block:: none
 
   $ pip install virtualenv
 
-.. note::
-  You need to make sure you have already installed pip in the previous step.
-
 Create a new directory for your odkdocs work:
 
-.. code-block:: rest
+.. code-block:: none
 
   $ mkdir odk
     
@@ -49,28 +37,28 @@ You have two options:
   - Use the native virtualenv.
   - Use virtualenvwrapper.
 
-
 .. _native-virenv:
 
 Native virtualenv
 ~~~~~~~~~~~~~~~~~~~~~
-Create a new python 3 virtual environment, "odkenv" is the name of the virtualenv, you are free to add your own.
 
-.. code-block:: rest
+Create a new Python 3 virtual environment, "odkenv" is the name of the virtualenv, you can add any name.
 
-  $ virtualenv --python=<python path/python.exe> odkenv
+.. code-block:: none
+
+  $ virtualenv -p <python path/python.exe> odkenv
  
-After creating python3 virtualenv in the previous step, multiple files are coppied into the folder odkenv.
+After creating python3 virtualenv in the previous step, multiple files are copied into the folder odkenv.
 
-.. code-block:: rest
+.. code-block:: none
 
   $ ls odkenv
 
-The folder Scripts contains all virtualenv control as bat files.
+The folder Scripts contains all virtualenv controls as ".bat" files.
 
 To activate the odkenv:
 
-.. code-block:: rest
+.. code-block:: none
 
   $ cd odkenv
   .
@@ -83,7 +71,7 @@ To activate the odkenv:
 
 To deactivate the odkenv:
 
-.. code-block:: rest
+.. code-block:: none
 
   $ odk/odkenv/Scripts/deactivate.bat
 
@@ -91,34 +79,34 @@ To deactivate the odkenv:
 
 Virtual Environment Wrapper
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Dealing with Virtualenv tool might be tiresome under windows. Thus, you are advised to install virtualenvwrapper tool using the following command.
 
-.. code-block:: rest
+Dealing with Virtualenv tool might be tiresome under windows. For simplicity, you can install `virtualenvwrapper <https://pypi.python.org/pypi/virtualenvwrapper-win>`_ tool using the following command.
+
+.. code-block:: none
 
   $ pip install virtualenvwrapper-win
 
-
 Create a new virtualenv use the command:
 
-.. code-block:: rest
+.. code-block:: none
 
   $ mkvirtualenv odkenv
 
-Once the odkenv is created, it is autoamtically activated, the current path in cmd will appear for example as:
+Once the odkenv is created, it is automatically activated, the current path in cmd will appear for example as:
 
-.. code-block:: rest
+.. code-block:: none
 
   $ (odkenv) C:/odk/docs
 
 To deactivate the odkenv, write:
 
-.. code-block:: rest
+.. code-block:: none
 
   $ deactivate
 
 To activate the odkenv any time:
 
-.. code-block:: rest
+.. code-block:: none
 
   $ workon odkenv
 
@@ -126,6 +114,7 @@ To activate the odkenv any time:
 
 Git and GLFS
 -------------------------------
+
   - Install `Git for windows <https://git-scm.com/downloads>`_.
 
 Make sure that git is installed properly by typing (git) in the cmd.
@@ -133,62 +122,56 @@ Make sure that git is installed properly by typing (git) in the cmd.
   - Install `GLFS <https://git-lfs.github.com/>`_.
 
 
-.. _andr-tools:
+.. _android-abd:
 
 Android Tools
 -------------------------------
-Android tools (Adb) by installing `Android studio <https://developer.android.com/studio/index.html/>`_
 
+Android tools (Adb) by installing `Android studio <https://developer.android.com/studio/index.html/>`_
 
 .. _fork-clone:
 
-Fork and Clone the docs repo
--------------------------------
-From github, fork the `odk docs <https://github.com/opendatakit/docs>`_ . this will create a copy od the docs in your account called ``origin``.
+Fork and Clone the ODK Docs repo
+---------------------------------
 
-Then Clone docs files into your local machine.
+From Github, fork the `ODK Docs <https://github.com/opendatakit/docs>`_. This will create a copy of the docs in your Github account called ``origin``. Move to the ODk working directory, and clone ODk Docs into your local machine.
 
-.. code-block:: rest
+.. code-block:: none
 
-  $ cd odk
-  .
-  .
-  .
   $ git clone https://github.com/your-github-username/docs.git
-
 
 .. _remote-upstream:
 
 Set the Upstream Remote
 ~~~~~~~~~~~~~~~~~~~~~~~~
-.. code-block:: rest
+
+.. code-block:: none
 
   $ git remote add upstream https://github.com/opendatakit/docs.git
 
-.. _requirs:
+.. _requirments:
 
 Install the requirements
 ------------------------
+
 First activate odkenv:
 
-.. code-block:: rest
+.. code-block:: none
 
   $ workon odkenv
 
-Make sure you are inside the docs folder Then run:
+Make sure you are inside the docs folder, then run:
 
-.. code-block:: rest
+.. code-block:: none
  
   $ pip install -r requirements.txt
 
 To this step, you will have ODKdocs environment ready. You can start change and build.
 
-Install Notepad++ to edit source files in windows from :
-
-Add `Notepad++ <https://notepad-plus-plus.org/download/v7.5.1.html/>`_ path to the enviroment variable
+You can work with any editor. You may install `Notepad++ <<https://notepad-plus-plus.org/download/v7.5.1.html/>`_ to edit source files. Add it to Windows Path in order to use it from command prompt.
 
 To edit docs files use: 
 
-.. code-block:: rest 
+.. code-block:: none
 
-  $ Notepad++ file.rst
+  $ Notepad++ filename.rst

--- a/cygwin.rst
+++ b/cygwin.rst
@@ -1,6 +1,6 @@
-*****************************
+******************************************
 Working with Docs in Windows using Cygwin
-*****************************
+******************************************
 
 Install Cygwin
 -------------------------------
@@ -39,8 +39,8 @@ You have two options:
 
 .. _native-virenv:
 
-Native virtualenv
-~~~~~~~~~~~~~~~~~~~~~
+Native Virtual Environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Create a new Python 3 virtual environment, "odkenv" is the name of the virtualenv, you can add any name.
 
@@ -151,7 +151,7 @@ Set the Upstream Remote
 
 .. _requirments:
 
-Install the requirements
+Install the Requirements
 ------------------------
 
 First activate odkenv:
@@ -168,7 +168,7 @@ Make sure you are inside the docs folder, then run:
 
 To this step, you will have ODKdocs environment ready. You can start change and build.
 
-You can work with any editor. You may install `Notepad++ <<https://notepad-plus-plus.org/download/v7.5.1.html/>`_ to edit source files. Add it to Windows Path in order to use it from command prompt.
+You can work with any editor. You may install `Notepad++ <https://notepad-plus-plus.org/download/v7.5.1.html/>`_ to edit source files. Add it to Windows Path in order to use it from command prompt.
 
 To edit docs files use: 
 

--- a/index.rst
+++ b/index.rst
@@ -57,6 +57,7 @@ For a complete list of our projects, check out `Open Data Kit on Github <https:/
   :caption: Contributing 
 
   contributing
+  cygwin
   
 .. toctree::
   :hidden:


### PR DESCRIPTION
I added instructions on setting up odk docs environment for windows using cygwin. I created (cygwin.rst) document and add a reference to the document in the index file under "Contributing to ODK Docs".

There is some repetition of steps in windows installation similar to linux; however, there are also some differences. It is possible also to integrate windows docs installation into the current (contributing.rst). We may add notes for windows under each step in the main contributing doc.

This is an issue #95