### PR TITLE
[WIP] Class added to style generic admonition like note.

### DIFF
--- a/_static/css/genericstyle.css
+++ b/_static/css/genericstyle.css
@@ -1,0 +1,23 @@
+.genericstyle {
+	background-attachment: scroll;
+	background-clip: border-box;
+	background-color: rgb(231, 242, 250);
+	background-image: none;
+	background-origin: padding-box;
+	background-position: 0% 0%;
+	background-position-x: 0%;
+	background-position-y: 0%;
+	background-repeat: repeat;
+	background-size: auto auto;
+	box-sizing: border-box;
+	color: rgb(64, 64, 64);
+	font-family: Georgia,"Times New Roman",serif;
+	font-size: 16px;
+	font-weight: 400;
+	line-height: 24px;
+	margin-bottom: 24px;
+	padding-bottom: 12px;
+	padding-left: 12px;
+	padding-right: 12px;
+	padding-top: 12px;
+}

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -1,4 +1,5 @@
 {% extends "!layout.html" %}
+{% set css_files = css_files + [ "_static/css/genericstyle.css" ] %}
 {% block extrahead %}
 
 <script>

--- a/conf.py
+++ b/conf.py
@@ -202,6 +202,7 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 
 def setup(app):
     app.add_stylesheet('css/custom.css')
+    app.add_stylesheet('css/genericstyle.css')
     
 
 # At top of every document


### PR DESCRIPTION
A new class called genericstyle has been added for styling generic admonitions. The styling is same as the styling for note. Please find the screenshots attached which show how an admonition looks like and how we can override the default styling. 
![black](https://user-images.githubusercontent.com/28952053/30378684-a21e7e92-98b1-11e7-8d7a-0260fdfc3848.png)
![heyy](https://user-images.githubusercontent.com/28952053/30378683-a219e2ce-98b1-11e7-84f8-39563fde02e7.png)

Closes https://github.com/opendatakit/docs/issues/98. 