### PR TITLE
Changes the code-block type for terminal commands

### DIFF
--- a/collect-adb.rst
+++ b/collect-adb.rst
@@ -28,7 +28,7 @@ Loading blank forms
 
 The forms are stored in :file:`sdcard/odk/forms/` folder on the device. They can be loaded via a USB device using:
 
-.. code-block:: none
+.. code-block:: console
 
   $ adb push path/to/form.xml /sdcard/odk/forms/form.xml
 
@@ -43,7 +43,7 @@ Deleting forms
 
 Forms can be deleted from :file:`sdcard/odk/forms` by running:
 
-.. code-block:: none
+.. code-block:: console
 
   $ adb shell rm -d /sdcard/odk/forms/my_form.xml
 
@@ -54,7 +54,7 @@ Downloading forms to your computer
 
 To download a completed form or form instance from the computer, run:
 
-.. code-block:: none
+.. code-block:: console
 
   $ adb pull /sdcard/odk/forms/my_form.xml
 
@@ -65,7 +65,7 @@ Downloading database
 
 Developers might also need to check the entries in the database from the computer. In such case pull the database file from the SD card and use any **SQLite visualizer** to view it. To pull the database into the computer, run:
 
-.. code-block:: none
+.. code-block:: console
   
   $  adb -pull /sdcard/odk/database/database.name
 
@@ -76,13 +76,13 @@ Saving screenshot
 
 For taking a screenshot, run:
 
-.. code-block:: none
+.. code-block:: console
 
   $ adb exec-out screencap /sdcard/screen.png
 
 Here, the image will be stored as ``screen.png`` which can be downloaded to the computer by running:
 
-.. code-block:: none
+.. code-block:: console
 
   $ adb pull /sdcard/screen.png
 
@@ -97,7 +97,7 @@ Recording a video
 
 :command:`adb` can be used to record video on device's screen. This can be done by running:
 
-.. code-block:: none
+.. code-block:: console
 
   $ adb shell screenrecord /sdcard/example.mp4
 

--- a/contributing.rst
+++ b/contributing.rst
@@ -201,9 +201,9 @@ Android Studio
 
 On Mac, add the following to your :file:`.bash_profile`
 
-.. code-block:: console
+.. code-block:: sh
 
-  $ export PATH=$PATH:~/Library/Android/sdk/tools/
+  export PATH=$PATH:~/Library/Android/sdk/tools/
 
 .. warning::
 
@@ -1328,6 +1328,10 @@ Use the ``code-block`` directive to markup code samples. Specify the language on
 
     print("Hello ODK!")
 
+  .. code-block:: console
+
+    $ python --version
+
   .. code-block:: java
 
     public class HelloWorld {
@@ -1338,8 +1342,4 @@ Use the ``code-block`` directive to markup code samples. Specify the language on
         }
 
     }
-
-.. note::
-
-    All command line examples in this documentation use ``console`` as the code-block type.
 

--- a/contributing.rst
+++ b/contributing.rst
@@ -502,7 +502,7 @@ Sphinx document files have the ``.rst`` extension. File names should be all lowe
 
 Normally, the title of the page should be the first line of the file, followed by the line of equal-signs.
 
-.. code-block:: none
+.. code-block:: rst
 
   Title of Page
   ================
@@ -511,7 +511,7 @@ Normally, the title of the page should be the first line of the file, followed b
 
 You can also wrap the title in two lines of asterisks.
 
-.. code-block:: none
+.. code-block:: rst
 
   *******************
   Title of Page
@@ -539,7 +539,7 @@ Sections and Titles
 
 Headlines require two lines: the text of the headline, followed by a line filled with a single character. Each level in a headline hierarchy uses a different character:
 
-.. code-block:: none
+.. code-block:: rst
 
   Title of the Page - <h1> - Equal Signs
   =========================================
@@ -562,7 +562,7 @@ Headlines require two lines: the text of the headline, followed by a line filled
 
 If you need to combine several existing pages together, or want to start a single-page doc that you think might be split into individual pages later on, you can add a top-level title, demoting the other headline types by one:
 
-.. code-block:: none
+.. code-block:: rst
 
   ************************************************
   Page Title - <h1> - Asterisks above and below
@@ -610,7 +610,7 @@ In order to facilitate efficient :ref:`cross-referencing`, sections should be la
 
 - a single colon
 
-.. code-block:: none
+.. code-block:: rst
 
   .. _section-label:
 
@@ -623,7 +623,7 @@ The section label is a slugified version of the section title.
 
 Section titles must be unique throughout the entire documentation set. Therefore, if you write a common title that might appear in more than one document (*Learn More* or *Getting Started*, for example), you'll need to include additional words to make the label unique. The best way to do this is to add a meaningful work from the document title.
 
-.. code-block:: none
+.. code-block:: rst
 
   ODK Aggregate
   ===============
@@ -645,7 +645,7 @@ Basic Markup
 
   Markup characters can be escaped using the ``\`` characters.
 
-  .. code-block:: none
+  .. code-block:: rst
 
     *Italic.*
 
@@ -660,7 +660,7 @@ Basic Markup
 Emphasis and Inline Literal
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code-block:: none
+.. code-block:: rst
 
   Single asterisks for *italic text* (``<em>``).
 
@@ -687,7 +687,7 @@ Hyperlinks
 
 **External** hyperlinks — that is, links to resources *outside* the documentation — look like this:
 
-.. code-block:: none
+.. code-block:: rst
 
   This is a link to `example <http://example.com>`_.
 
@@ -695,7 +695,7 @@ This is a link to `example <http://example.com>`_.
 
 You can also use "reference style" links:
 
-.. code-block:: none
+.. code-block:: rst
 
   This is a link to `example`_.
 
@@ -703,7 +703,7 @@ You can also use "reference style" links:
 
 This may help make paragraphs with *a lot* of links more readable. In general, the inline style is preferable. If you use the reference style, be sure to keep the link references below the paragraph where they appear.
 
-.. code-block:: none
+.. code-block:: rst
 
   You can also simply place an unadorned URI in the text: http://example.com
 
@@ -719,7 +719,7 @@ Lists
 Unordered (bullet) lists
 """""""""""""""""""""""""""
 
-.. code-block:: none
+.. code-block:: rst
 
   Bulleted lists ( ``<ul>`` ):
 
@@ -748,7 +748,7 @@ Bulleted lists ( ``<ul>`` ):
 Ordered (numbered) lists
 """"""""""""""""""""""""""
 
-.. code-block:: none
+.. code-block:: rst
 
   Numbered lists ( ``<ol>`` ):
 
@@ -779,7 +779,7 @@ Numbered lists ( ``<ol>`` ):
 Definition Lists
 """""""""""""""""""
 
-.. code-block:: none
+.. code-block:: rst
 
   Definition list ( ``<dl>`` )
     a list with several term-definition pairs
@@ -812,7 +812,7 @@ Line spacing
 Paragraph-level Markup
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code-block:: none
+.. code-block:: rst
 
   Paragraphs are separated by blank lines. Line breaks in the source code do not create line breaks in the output.
 
@@ -843,7 +843,7 @@ There is **no reason** to put a limit on line length in source files for documen
 Block Quotes
 """"""""""""""
 
-.. code-block:: none
+.. code-block:: rst
 
   This is not a block quote. Block quotes are indented, and otherwise unadorned.
 
@@ -860,7 +860,7 @@ This is not a block quote. Block quotes are indented, and otherwise unadorned.
 Line Blocks
 """"""""""""
 
-.. code-block:: none
+.. code-block:: rst
 
   | Line blocks are useful for addresses,
   | verse, and adornment-free lists.
@@ -890,7 +890,7 @@ Tables
 Grid style
 ''''''''''''
 
-.. code-block:: none
+.. code-block:: rst
 
   +------------+------------+-----------+
   | Header 1   | Header 2   | Header 3  |
@@ -922,7 +922,7 @@ Simple style
 ''''''''''''''
 
 
-.. code-block:: none
+.. code-block:: rst
 
   =====  =====  ======
      Inputs     Output
@@ -977,7 +977,7 @@ Cross referencing
 
 Cross referencing is linking internally, from one place in the documentation to another. This is **not** done using the :ref:`hyperlinks` syntax, but with one of the several roles:
 
-.. code-block:: none
+.. code-block:: rst
 
   :role:`target`
     becomes...
@@ -1011,7 +1011,7 @@ Cross referencing is linking internally, from one place in the documentation to 
 
 For example:
 
-.. code-block:: none
+.. code-block:: rst
 
   - Link to this document:
 
@@ -1054,7 +1054,7 @@ Several roles are used when describing user interactions.
 
   Marks up *actual UI text* of form labels or buttons.
 
-  .. code-block:: none
+  .. code-block:: rst
 
     Press the :guilabel:`Submit` button.
 
@@ -1129,7 +1129,7 @@ Custom text roles used in ODK documentation are:
   - Sent
   - Deleted
   
-  .. code-block:: rest
+  .. code-block:: rst
     
     :formstate:`Sent`
 
@@ -1137,7 +1137,7 @@ Custom text roles used in ODK documentation are:
     
   Describes a touch screen gesture. 
 
-  .. code-block:: rest
+  .. code-block:: rst
     
     :gesture:`Swipe Left`
 
@@ -1285,7 +1285,7 @@ The length of the videos must be less than a minute.
 
 There is no ``video`` directive to add a video, so to add a video in a document, you can do the following:
 
-.. code-block:: console
+.. code-block:: none
   
   .. raw:: html
 
@@ -1338,3 +1338,8 @@ Use the ``code-block`` directive to markup code samples. Specify the language on
         }
 
     }
+
+.. note::
+
+    All command line examples in this documentation use ``none`` as the code-block type.
+

--- a/contributing.rst
+++ b/contributing.rst
@@ -1260,7 +1260,7 @@ If you have set up local :ref:`android-tools`, you can connect your Android devi
 
 Now, at the command line, from the root directory of the :file:`odk-docs` repo:
 
-.. code-block:: none
+.. code-block:: console
 
   python ss.py {document-name}/{image-name}
 
@@ -1285,7 +1285,7 @@ The length of the videos must be less than a minute.
 
 There is no ``video`` directive to add a video, so to add a video in a document, you can do the following:
 
-.. code-block:: none
+.. code-block:: rst
   
   .. raw:: html
 
@@ -1295,7 +1295,7 @@ There is no ``video`` directive to add a video, so to add a video in a document,
 
 **ADB or Android Debug Bridge** can be used to capture a screen recording from collect. This can be done by entering:
 
-.. code-block:: none
+.. code-block:: console
 
   $ adb shell screenrecord /sdcard/example.mp4
 
@@ -1305,7 +1305,7 @@ The video file is saved in your Android device to a file at :file:`/sdcard/examp
 
 To pull the video locally just type the following command and hit :command:`Enter`.
 
-.. code-block:: none
+.. code-block:: console
   
   $ adb pull /sdcard/example.mp4 localsavelocation
 

--- a/contributing.rst
+++ b/contributing.rst
@@ -83,7 +83,7 @@ Python 3
 
 If you don't know, check to see if you have Python 3 installed:
 
-.. code-block:: rest
+.. code-block:: none
 
   $ python3
 
@@ -98,7 +98,7 @@ A virtual environment is a Python tool for sandboxing dependencies. It lets you 
 
 Check to see if you have virtualenv installed:
 
-.. code-block:: rest
+.. code-block:: none
 
   $ virtualenv
 
@@ -106,20 +106,20 @@ If you get a help message with information about commands, you have it. If you d
 
 In case you don't have it, install it using ``pip`` by running:
 
-.. code-block:: rest
+.. code-block:: none
 
   $ pip install virtualenv
 
 Then, create an ODK "master" directory. This will contain your virtualenv and the docs repo as subdirectories.
 
-.. code-block:: rest
+.. code-block:: none
 
   $ mkdir odk
   $ cd odk
 
 Now, inside that odk directory, create a python3 virtualenv.
 
-.. code-block:: rest
+.. code-block:: none
 
   $ virtualenv -p python3 odkenv
 
@@ -127,13 +127,13 @@ The last part, ``odkenv`` can be whatever name you'd like to call it.
 
 Activate your virtual environment with:
 
-.. code-block:: rest
+.. code-block:: none
 
   $ source odkenv/bin/activate
 
 And, when you are done working, deactivate it with:
 
-.. code-block:: rest
+.. code-block:: none
 
   $ deactivate
 
@@ -201,7 +201,7 @@ Android Studio
 
 On Mac, add the following to your :file:`.bash_profile`
 
-.. code-block:: none
+.. code-block:: console
 
   export PATH=$PATH:~/Library/Android/sdk/tools/
 
@@ -240,7 +240,7 @@ From your own form of the repo on Github, select the :guilabel:`Clone or downloa
 
 Open your terminal, and `cd` to your preferred directory. Then `git clone` the repo:
 
-.. code-block:: rest
+.. code-block:: none
 
   $ git clone https://github.com/your-github-username/docs.git
   .
@@ -261,13 +261,13 @@ Set the Upstream Remote
 
 When you clone down a repo, the local copy calls your GitHub copy ``origin``. You should also set ``upstream`` as the name of the original, main GitHub repo.
 
-.. code-block:: rest
+.. code-block:: none
 
   $ git remote add --track upstream https://github.com/opendatakit/docs.git
 
 Run ``git remote -v`` to check the status, you should see something like this:
 
-.. code-block:: rest
+.. code-block:: none
 
   $ origin https://github.com/your-github-username/docs.git (fetch)
   $ origin https://github.com/your-github-username/docs.git (push)
@@ -281,7 +281,7 @@ Install Dependencies
 
 The first time you clone down the repo, you'll need to install the dependencies. Make sure you have your Python 3 virtual environment set up and activated and then:
 
-.. code-block:: rest
+.. code-block:: none
 
   $ pip install -r requirements.txt
 
@@ -305,7 +305,7 @@ Pull in Updates from Upstream
 
 You probably won't need to do this the first time, but you should always pull in any changes from the main repository before working.
 
-.. code-block:: rest
+.. code-block:: none
 
   $ git pull upstream
 
@@ -318,7 +318,7 @@ Choose a specific, deliverable task to work on. This should be an `active issue 
 
 Create a new branch in which you will work on this specific issue. The branch name should briefly describe what you are doing. For example, the original author of this contributor guide worked in a branch he called ``contributing``. Also, make sure that all the branches are derived from the ``master`` branch to avoid intermixing of commits.
 
-.. code-block:: rest
+.. code-block:: none
 
   $ git checkout -b branch-name
 
@@ -355,7 +355,7 @@ Build, View, and Debug
 
 To build the documentation into a viewable website:
 
-.. code-block:: rest
+.. code-block:: none
 
   $ sphinx-build -b html . build
 
@@ -372,7 +372,7 @@ Error and warning messages include a file name and line number for tracking them
 
 To view the documentation in your web browser, you can use Python's built-in web server.
 
-.. code-block:: rest
+.. code-block:: none
 
   $ cd build
   $ python -m http.server 8000
@@ -383,7 +383,7 @@ Read through your doc edits in the browser and correct any issues in your source
 
 It's a good idea to delete the ``build`` directory before each rebuild.
 
-.. code-block:: rest
+.. code-block:: none
 
   $ rm -rf build
   $ sphinx-build -b html . build
@@ -395,20 +395,20 @@ Push Your Branch
 
 Once your work on the issue is completed, add the files you've changed or created additionally, and write a relevant commit message describing the changes.
 
-.. code-block:: rest
+.. code-block:: none
 
   $ git add my_changed_files
   $ git commit -m "A small but relevant commit message"
 
 Then it's time to push the changes. The first time you do this on any branch, you'll need to specify the branch name:
 
-.. code-block:: rest
+.. code-block:: none
 
   $ git push origin branch-name
 
 After that, you can just:
 
-.. code-block:: rest
+.. code-block:: none
 
   $ git push
 
@@ -445,20 +445,20 @@ Keep Going
 
 Once the PR is merged, you'll need to pull in the changes from the main repo ( ``upstream`` ) into your local copy.
 
-.. code-block:: rest
+.. code-block:: none
 
   $ git checkout master
   $ git pull upstream master
 
 Then you should push those change to your copy on GitHub ( ``origin`` ).
 
-.. code-block:: rest
+.. code-block:: none
 
   $ git push
 
 If you want to delete your branch from before, you can do that:
 
-.. code-block:: rest
+.. code-block:: none
 
   $ git branch -d branch-name
 
@@ -502,7 +502,7 @@ Sphinx document files have the ``.rst`` extension. File names should be all lowe
 
 Normally, the title of the page should be the first line of the file, followed by the line of equal-signs.
 
-.. code-block:: rst
+.. code-block:: none
 
   Title of Page
   ================
@@ -511,7 +511,7 @@ Normally, the title of the page should be the first line of the file, followed b
 
 You can also wrap the title in two lines of asterisks.
 
-.. code-block:: rst
+.. code-block:: none
 
   *******************
   Title of Page
@@ -539,7 +539,7 @@ Sections and Titles
 
 Headlines require two lines: the text of the headline, followed by a line filled with a single character. Each level in a headline hierarchy uses a different character:
 
-.. code-block:: rest
+.. code-block:: none
 
   Title of the Page - <h1> - Equal Signs
   =========================================
@@ -562,7 +562,7 @@ Headlines require two lines: the text of the headline, followed by a line filled
 
 If you need to combine several existing pages together, or want to start a single-page doc that you think might be split into individual pages later on, you can add a top-level title, demoting the other headline types by one:
 
-.. code-block:: rest
+.. code-block:: none
 
   ************************************************
   Page Title - <h1> - Asterisks above and below
@@ -610,7 +610,7 @@ In order to facilitate efficient :ref:`cross-referencing`, sections should be la
 
 - a single colon
 
-.. code-block:: rest
+.. code-block:: none
 
   .. _section-label:
 
@@ -623,7 +623,7 @@ The section label is a slugified version of the section title.
 
 Section titles must be unique throughout the entire documentation set. Therefore, if you write a common title that might appear in more than one document (*Learn More* or *Getting Started*, for example), you'll need to include additional words to make the label unique. The best way to do this is to add a meaningful work from the document title.
 
-.. code-block:: rest
+.. code-block:: none
 
   ODK Aggregate
   ===============
@@ -645,7 +645,7 @@ Basic Markup
 
   Markup characters can be escaped using the ``\`` characters.
 
-  .. code-block:: rest
+  .. code-block:: none
 
     *Italic.*
 
@@ -660,7 +660,7 @@ Basic Markup
 Emphasis and Inline Literal
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code-block:: rest
+.. code-block:: none
 
   Single asterisks for *italic text* (``<em>``).
 
@@ -687,7 +687,7 @@ Hyperlinks
 
 **External** hyperlinks — that is, links to resources *outside* the documentation — look like this:
 
-.. code-block:: rest
+.. code-block:: none
 
   This is a link to `example <http://example.com>`_.
 
@@ -695,7 +695,7 @@ This is a link to `example <http://example.com>`_.
 
 You can also use "reference style" links:
 
-.. code-block:: rest
+.. code-block:: none
 
   This is a link to `example`_.
 
@@ -703,7 +703,7 @@ You can also use "reference style" links:
 
 This may help make paragraphs with *a lot* of links more readable. In general, the inline style is preferable. If you use the reference style, be sure to keep the link references below the paragraph where they appear.
 
-.. code-block:: rest
+.. code-block:: none
 
   You can also simply place an unadorned URI in the text: http://example.com
 
@@ -719,7 +719,7 @@ Lists
 Unordered (bullet) lists
 """""""""""""""""""""""""""
 
-.. code-block:: rest
+.. code-block:: none
 
   Bulleted lists ( ``<ul>`` ):
 
@@ -748,7 +748,7 @@ Bulleted lists ( ``<ul>`` ):
 Ordered (numbered) lists
 """"""""""""""""""""""""""
 
-.. code-block:: rest
+.. code-block:: none
 
   Numbered lists ( ``<ol>`` ):
 
@@ -779,7 +779,7 @@ Numbered lists ( ``<ol>`` ):
 Definition Lists
 """""""""""""""""""
 
-.. code-block:: rest
+.. code-block:: none
 
   Definition list ( ``<dl>`` )
     a list with several term-definition pairs
@@ -812,7 +812,7 @@ Line spacing
 Paragraph-level Markup
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code-block:: rest
+.. code-block:: none
 
   Paragraphs are separated by blank lines. Line breaks in the source code do not create line breaks in the output.
 
@@ -843,7 +843,7 @@ There is **no reason** to put a limit on line length in source files for documen
 Block Quotes
 """"""""""""""
 
-.. code-block:: rest
+.. code-block:: none
 
   This is not a block quote. Block quotes are indented, and otherwise unadorned.
 
@@ -860,7 +860,7 @@ This is not a block quote. Block quotes are indented, and otherwise unadorned.
 Line Blocks
 """"""""""""
 
-.. code-block:: rest
+.. code-block:: none
 
   | Line blocks are useful for addresses,
   | verse, and adornment-free lists.
@@ -890,7 +890,7 @@ Tables
 Grid style
 ''''''''''''
 
-.. code-block:: rest
+.. code-block:: none
 
   +------------+------------+-----------+
   | Header 1   | Header 2   | Header 3  |
@@ -922,7 +922,7 @@ Simple style
 ''''''''''''''
 
 
-.. code-block:: rest
+.. code-block:: none
 
   =====  =====  ======
      Inputs     Output
@@ -1011,7 +1011,7 @@ Cross referencing is linking internally, from one place in the documentation to 
 
 For example:
 
-.. code-block:: rst
+.. code-block:: none
 
   - Link to this document:
 
@@ -1054,7 +1054,7 @@ Several roles are used when describing user interactions.
 
   Marks up *actual UI text* of form labels or buttons.
 
-  .. code-block:: rst
+  .. code-block:: none
 
     Press the :guilabel:`Submit` button.
 
@@ -1285,7 +1285,7 @@ The length of the videos must be less than a minute.
 
 There is no ``video`` directive to add a video, so to add a video in a document, you can do the following:
 
-.. code-block:: rst
+.. code-block:: console
   
   .. raw:: html
 

--- a/contributing.rst
+++ b/contributing.rst
@@ -83,7 +83,7 @@ Python 3
 
 If you don't know, check to see if you have Python 3 installed:
 
-.. code-block:: none
+.. code-block:: console
 
   $ python3
 
@@ -98,7 +98,7 @@ A virtual environment is a Python tool for sandboxing dependencies. It lets you 
 
 Check to see if you have virtualenv installed:
 
-.. code-block:: none
+.. code-block:: console
 
   $ virtualenv
 
@@ -106,20 +106,20 @@ If you get a help message with information about commands, you have it. If you d
 
 In case you don't have it, install it using ``pip`` by running:
 
-.. code-block:: none
+.. code-block:: console
 
   $ pip install virtualenv
 
 Then, create an ODK "master" directory. This will contain your virtualenv and the docs repo as subdirectories.
 
-.. code-block:: none
+.. code-block:: console
 
   $ mkdir odk
   $ cd odk
 
 Now, inside that odk directory, create a python3 virtualenv.
 
-.. code-block:: none
+.. code-block:: console
 
   $ virtualenv -p python3 odkenv
 
@@ -127,13 +127,13 @@ The last part, ``odkenv`` can be whatever name you'd like to call it.
 
 Activate your virtual environment with:
 
-.. code-block:: none
+.. code-block:: console
 
   $ source odkenv/bin/activate
 
 And, when you are done working, deactivate it with:
 
-.. code-block:: none
+.. code-block:: console
 
   $ deactivate
 
@@ -165,14 +165,14 @@ GLFS tracks binary files as defined in the :file:`.gitattributes` file `in the r
 
 If you are adding binary files to the repo, and they are in formats not already tracked, **it is your responsibility to make sure they are tracked.** To make sure they are properly tracked, add the file type to GLFS. You can do this by editing :file:`.gitattributes` directly.
 
-.. code-block:: none
+.. code-block:: console
 
   # file type section heading
   *.{extension-to-track} filter=lfs diff=lfs merge=lfs -text
 
 You can also use the command line.
 
-.. code-block:: none
+.. code-block:: console
 
   $ glfs track *.{file-extension}
 
@@ -203,7 +203,7 @@ On Mac, add the following to your :file:`.bash_profile`
 
 .. code-block:: console
 
-  export PATH=$PATH:~/Library/Android/sdk/tools/
+  $ export PATH=$PATH:~/Library/Android/sdk/tools/
 
 .. warning::
 
@@ -240,7 +240,7 @@ From your own form of the repo on Github, select the :guilabel:`Clone or downloa
 
 Open your terminal, and `cd` to your preferred directory. Then `git clone` the repo:
 
-.. code-block:: none
+.. code-block:: console
 
   $ git clone https://github.com/your-github-username/docs.git
   .
@@ -261,13 +261,13 @@ Set the Upstream Remote
 
 When you clone down a repo, the local copy calls your GitHub copy ``origin``. You should also set ``upstream`` as the name of the original, main GitHub repo.
 
-.. code-block:: none
+.. code-block:: console
 
   $ git remote add --track upstream https://github.com/opendatakit/docs.git
 
 Run ``git remote -v`` to check the status, you should see something like this:
 
-.. code-block:: none
+.. code-block:: console
 
   $ origin https://github.com/your-github-username/docs.git (fetch)
   $ origin https://github.com/your-github-username/docs.git (push)
@@ -281,7 +281,7 @@ Install Dependencies
 
 The first time you clone down the repo, you'll need to install the dependencies. Make sure you have your Python 3 virtual environment set up and activated and then:
 
-.. code-block:: none
+.. code-block:: console
 
   $ pip install -r requirements.txt
 
@@ -305,7 +305,7 @@ Pull in Updates from Upstream
 
 You probably won't need to do this the first time, but you should always pull in any changes from the main repository before working.
 
-.. code-block:: none
+.. code-block:: console
 
   $ git pull upstream
 
@@ -318,7 +318,7 @@ Choose a specific, deliverable task to work on. This should be an `active issue 
 
 Create a new branch in which you will work on this specific issue. The branch name should briefly describe what you are doing. For example, the original author of this contributor guide worked in a branch he called ``contributing``. Also, make sure that all the branches are derived from the ``master`` branch to avoid intermixing of commits.
 
-.. code-block:: none
+.. code-block:: console
 
   $ git checkout -b branch-name
 
@@ -355,7 +355,7 @@ Build, View, and Debug
 
 To build the documentation into a viewable website:
 
-.. code-block:: none
+.. code-block:: console
 
   $ sphinx-build -b html . build
 
@@ -372,7 +372,7 @@ Error and warning messages include a file name and line number for tracking them
 
 To view the documentation in your web browser, you can use Python's built-in web server.
 
-.. code-block:: none
+.. code-block:: console
 
   $ cd build
   $ python -m http.server 8000
@@ -383,7 +383,7 @@ Read through your doc edits in the browser and correct any issues in your source
 
 It's a good idea to delete the ``build`` directory before each rebuild.
 
-.. code-block:: none
+.. code-block:: console
 
   $ rm -rf build
   $ sphinx-build -b html . build
@@ -395,20 +395,20 @@ Push Your Branch
 
 Once your work on the issue is completed, add the files you've changed or created additionally, and write a relevant commit message describing the changes.
 
-.. code-block:: none
+.. code-block:: console
 
   $ git add my_changed_files
   $ git commit -m "A small but relevant commit message"
 
 Then it's time to push the changes. The first time you do this on any branch, you'll need to specify the branch name:
 
-.. code-block:: none
+.. code-block:: console
 
   $ git push origin branch-name
 
 After that, you can just:
 
-.. code-block:: none
+.. code-block:: console
 
   $ git push
 
@@ -445,20 +445,20 @@ Keep Going
 
 Once the PR is merged, you'll need to pull in the changes from the main repo ( ``upstream`` ) into your local copy.
 
-.. code-block:: none
+.. code-block:: console
 
   $ git checkout master
   $ git pull upstream master
 
 Then you should push those change to your copy on GitHub ( ``origin`` ).
 
-.. code-block:: none
+.. code-block:: console
 
   $ git push
 
 If you want to delete your branch from before, you can do that:
 
-.. code-block:: none
+.. code-block:: console
 
   $ git branch -d branch-name
 
@@ -1341,5 +1341,5 @@ Use the ``code-block`` directive to markup code samples. Specify the language on
 
 .. note::
 
-    All command line examples in this documentation use ``none`` as the code-block type.
+    All command line examples in this documentation use ``console`` as the code-block type.
 


### PR DESCRIPTION
This PR adds the following changes:
* It changed the default console type commands to use `none` as code-block type.
* Some of the restructured text examples used `rest`, changed all of them to `rst`, which is in accordance with the guide itself.
* Added a note for the use of `none`.