### PR TITLE
Move pngquant as part of test. Move s3_website as part of deploy.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,6 @@
 dependencies:
     pre:
       - sudo apt-get install pngquant
-      - gem install s3_website && s3_website install
 
 test:
   pre:
@@ -12,6 +11,7 @@ test:
 
   override:
     - sphinx-build -W -b dirhtml $HOME/docs $HOME/docs/build
+    - pngquant $HOME/docs/build/_images/*.png --force --ext .png
 
   post:
     - cp -r $HOME/docs/build $CIRCLE_ARTIFACTS
@@ -21,5 +21,5 @@ deployment:
     branch: master
     owner: opendatakit
     commands:
-      - pngquant $HOME/docs/build/_images/*.png --force --ext .png
+      - gem install s3_website && s3_website install
       - s3_website push --config-dir $HOME/docs

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ test:
 
   override:
     - sphinx-build -W -b dirhtml $HOME/docs $HOME/docs/build
-    - pngquant $HOME/docs/build/_images/*.png --force --ext .png
+    - pngquant $HOME/docs/build/_images/*.png --force --ext .png --verbose
 
   post:
     - cp -r $HOME/docs/build $CIRCLE_ARTIFACTS


### PR DESCRIPTION
Bad pngs can cause pngquant to fail before a build goes to production (See https://github.com/opendatakit/docs/issues/323). We should catch this issue when the initial PR is sent in. For this reason, we should run pngquant as part of the test. This makes for slower builds when a PR is sent in, but so be it. I'd rather we catch this before we merge.

We only need to use s3_website when deploying to production, so rather than install it on each commit, we only install it when deploying to production.