### PR TITLE
Form design intro

### DIFF
--- a/form-design-intro.rst
+++ b/form-design-intro.rst
@@ -1,5 +1,37 @@
-Intro to Form Design
+Intro to Forms in ODK
 ========================
 
-Forms used in the ODK ecosystem are XML documents following the `ODK XForms specification <https://opendatakit.github.io/xforms-spec/>`_, a subset of the `W3C XForms specification <https://www.w3.org/TR/xforms/>`_.
+Forms used in the ODK ecosystem are XML documents following the `ODK XForms specification <https://opendatakit.github.io/xforms-spec/>`_, a subset of the `W3C XForms specification <https://www.w3.org/TR/xforms/>`_. Most ODK tools use the `ODK Javarosa <https://github.com/opendatakit/javarosa>`_ library to render forms. Form transfer between ODK components is governed by the :doc:`openrosa` API.
+
+Because of the complexity of the XForms format, we do not recommend "hand-coding" XForms. The recommended process is:
+
+- Begin with one of the :ref:`compliant-build-tools`.
+- :ref:`Edit the XML only if neccessary <>`.
+- Use :doc:`validate` to check that form is well-formed and fully compliant.
+
+
+.. _compliant-build-tools:
+
+JavaRosa-compliant build tools
+---------------------------------
+
+Most ODK users design their forms in Excel, following the `XLSForm <http://xlsform.org/>`_ specification. To convert XLSForms to XForms, you can use:
+
+- `ODK's online XLSForm converter <http://opendatakit.org/xiframe/>`_
+- `XLSForm Offline for Mac or Windows <https://gumroad.com/l/xlsform-offline>`_
+- - `XLSForm for Windows <https://opendatakit.org/downloads/download-info/xlsform-for-windows/>`_
+- `Pyxform, a Python XLSForm conversion library <https://github.com/uw-ictd/pyxform>`_
+
+For simple forms, `ODK Build <https://opendatakit.org/use/build/>`_ is an online drag-and-drop form designer.
+
+.. _other-xform-build-tools:
+
+Other XForm build tools
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These tools product XForms that *may not* strictly comply with the JavaRosa library. 
+
+- `Kobo <http://www.kobotoolbox.org/>`_
+- `Enketo <https://enketo.org/>`_
+- `purcforms <https://code.google.com/archive/p/purcforms/>`_
 

--- a/form-design-intro.rst
+++ b/form-design-intro.rst
@@ -5,9 +5,12 @@ Forms used in the ODK ecosystem are XML documents following the `ODK XForms spec
 
 Because of the complexity of the XForms format, we do not recommend "hand-coding" XForms. The recommended process is:
 
-- Begin with one of the :ref:`compliant-build-tools`.
-- :ref:`Edit the XML only if neccessary <>`.
-- Use :doc:`validate` to check that form is well-formed and fully compliant.
+1. Begin with one of the :ref:`compliant-build-tools`.
+2. Edit the XML only if neccessary.
+
+   - Before editing an XForm directly, you need to be familiar with the `ODK XForm specification <https://github.com/opendatakit/xforms-spec>`_.
+
+3. Use :doc:`validate` to check that the edited XForm is well-formed and fully compliant.
 
 
 .. _compliant-build-tools:
@@ -19,17 +22,26 @@ Most ODK users design their forms in Excel, following the `XLSForm <http://xlsfo
 
 - `ODK's online XLSForm converter <http://opendatakit.org/xiframe/>`_
 - `XLSForm Offline for Mac or Windows <https://gumroad.com/l/xlsform-offline>`_
-- - `XLSForm for Windows <https://opendatakit.org/downloads/download-info/xlsform-for-windows/>`_
-- `Pyxform, a Python XLSForm conversion library <https://github.com/uw-ictd/pyxform>`_
+- `XLSForm for Windows <https://opendatakit.org/downloads/download-info/xlsform-for-windows/>`_
+- :doc:`pyxform`, a Python XLSForm converter with a command-line tool
 
-For simple forms, `ODK Build <https://opendatakit.org/use/build/>`_ is an online drag-and-drop form designer.
+.. tip::
+
+  If you are comfortable with using the command-line, Pyxform is the most efficient XLSForm converter.
+
+.. _non-xlsform-builders:
+
+Non-XLSForm Javarosa builders
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  
+For simple forms, :doc:`odk-build` is an online drag-and-drop form designer.
 
 .. _other-xform-build-tools:
 
 Other XForm build tools
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-These tools product XForms that *may not* strictly comply with the JavaRosa library. 
+These tools produce XForms that *may not* strictly comply with the JavaRosa library. 
 
 - `Kobo <http://www.kobotoolbox.org/>`_
 - `Enketo <https://enketo.org/>`_

--- a/form-design-intro.rst
+++ b/form-design-intro.rst
@@ -1,0 +1,5 @@
+Intro to Form Design
+========================
+
+Forms used in the ODK ecosystem are XML documents following the `ODK XForms specification <https://opendatakit.github.io/xforms-spec/>`_, a subset of the `W3C XForms specification <https://www.w3.org/TR/xforms/>`_.
+

--- a/form-design-intro.rst
+++ b/form-design-intro.rst
@@ -1,9 +1,11 @@
 Intro to Forms in ODK
 ========================
 
-Forms used in the ODK ecosystem are XML documents following the `ODK XForms specification <https://opendatakit.github.io/xforms-spec/>`_, a subset of the `W3C XForms specification <https://www.w3.org/TR/xforms/>`_. Most ODK tools use the `ODK Javarosa <https://github.com/opendatakit/javarosa>`_ library to render forms. Form transfer between ODK components is governed by the :doc:`openrosa` API.
+Forms used in the ODK ecosystem are XML documents following the `ODK XForms specification <https://opendatakit.github.io/xforms-spec/>`_, a subset of the `W3C XForms specification <https://www.w3.org/TR/xforms/>`_. (`Example XForms are available for reference. <https://github.com/opendatakit/sample-forms>`_)
 
-Because of the complexity of the XForms format, we do not recommend "hand-coding" XForms. The recommended process is:
+Most ODK tools use the `ODK Javarosa <https://github.com/opendatakit/javarosa>`_ library to render forms. Form transfer between ODK components is governed by the :doc:`openrosa` API.
+
+Because of the complexity of the XForms format, we do not recommend coding XForms directly in XML. The recommended process is:
 
 1. Begin with one of the :ref:`compliant-build-tools`.
 2. Edit the XML only if neccessary.
@@ -35,15 +37,3 @@ Non-XLSForm Javarosa builders
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   
 For simple forms, :doc:`odk-build` is an online drag-and-drop form designer.
-
-.. _other-xform-build-tools:
-
-Other XForm build tools
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-These tools produce XForms that *may not* strictly comply with the JavaRosa library. 
-
-- `Kobo <http://www.kobotoolbox.org/>`_
-- `Enketo <https://enketo.org/>`_
-- `purcforms <https://code.google.com/archive/p/purcforms/>`_
-

--- a/index.rst
+++ b/index.rst
@@ -74,6 +74,7 @@ For a complete list of our projects, check out `Open Data Kit on Github <https:/
   :maxdepth: 2
   :caption: Form Building
 
+  form-design-intro
   odk-build
   xlsform
   form-widgets


### PR DESCRIPTION
addresses #239 
addresses #332

## What is included in this PR?

A new doc at the top of the Form Building TOC that provides an overview of how forms work in ODK ecosystem. 

This is roughly analogous to https://opendatakit.org/help/form-design/

## What is left to be done in the addressed issue?

The [original page](https://opendatakit.org/help/form-design/) has a number of sub pages, only some of which will be pulled in.

I'm also going to move some pages around and do some editing, but since this doc is useful immediately, I thought it was more sensible to do a standalone PR for it.