### PR TITLE
Added script to convert the color profile

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ Sphinx==1.6.1
 sphinx-rtd-theme==0.2.4
 sphinxcontrib-websupport==1.0.1
 typing==3.6.1
-update==0.4.4
+Pillow==4.3.0

--- a/ss.py
+++ b/ss.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 
-
 import os
 import subprocess
 import sys
+import PIL.Image
+import PIL.ImageCms
+import tempfile
 
 def ensure_dir(file_path):
     directory = os.path.dirname(file_path)
@@ -17,11 +19,22 @@ def save_screencap(cap, filename):
     with open(filename, 'wb') as f:
         f.write(cap)
 
+def convert_profile(filename):
+    img = PIL.Image.open(filename)
+    icc = tempfile.mkstemp(suffix='.icc')[1]
+    if 'icc_profile' in img.info:
+        with open(icc, 'wb') as f:
+            f.write(img.info['icc_profile'])
+        srgb = PIL.ImageCms.createProfile('sRGB')
+        img = PIL.ImageCms.profileToProfile(img, icc, srgb)
+    img.save(filename)
+
 if __name__ == "__main__":
     short_filename = sys.argv[1]
     filename = 'img/' + short_filename + '.png'
     ensure_dir(filename)
     save_screencap(screencap(), filename)
+    convert_profile(filename)
     if sys.argv[2] != '-s':
         print("Insert image into doc with:")
         print(".. image:: /img/" + short_filename + ".*")


### PR DESCRIPTION
<!-- ALL PRs MUST BE RELATED TO AN OPEN ISSUE -->
closes #330 

## What is included in this PR?
I've added a function that checks and converts the color profile of bad pngs. 
I've added a temp.py for testing purposes and jumpscreen.png(a bad png) in img/collect-settings. The script can be tested on this bad png(it successfully converts the color profile) and on any other png.
I'll remove the files once the script has been finalized, however it's ready for review now.    

