### PR TITLE
Moves dev-focused docs to own section

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -81,7 +81,6 @@ For a complete list of our projects, check out `Open Data Kit on Github <https:/
   xlsform
   form-widgets
   form-interaction
-  javarosa
   pyxform
   validate
 
@@ -94,6 +93,14 @@ For a complete list of our projects, check out `Open Data Kit on Github <https:/
   cygwin
   contributing-tips
   style-guide
+
+.. toctree::
+  :hidden:
+  :maxdepth: 2
+  :caption: Developing with ODK 
+  
+  openrosa
+  javarosa
   
 .. toctree::
   :hidden:
@@ -101,18 +108,6 @@ For a complete list of our projects, check out `Open Data Kit on Github <https:/
   :caption: Integration
   
   encrypted-forms
-
-.. toctree::
-  :hidden:
-  :maxdepth: 2
-  :caption: OpenRosa
-  
-  openrosa
-  openrosa-metadata
-  openrosa-http
-  openrosa-authentication
-  openrosa-form-submission
-  openrosa-form-list
 
 .. toctree::
   :hidden:

--- a/openrosa.rst
+++ b/openrosa.rst
@@ -14,8 +14,12 @@ OpenRosa 1.0 APIs
 
 OpenRosa 1.0 APIs were formally approved by the OpenRosa Working Group in December of 2011. To be considered "OpenRosa 1.0 Compliant," a system must implement all 5 of the OpenRosa 1.0 APIs.
 
-- :doc:`openrosa-metadata`
-- :doc:`openrosa-http`
-- :doc:`openrosa-form-submission`
-- :doc:`openrosa-authentication`
-- :doc:`openrosa-form-list`
+
+.. toctree::
+  :maxdepth: 2
+ 
+  openrosa-metadata
+  openrosa-http
+  openrosa-authentication
+  openrosa-form-submission
+  openrosa-form-list


### PR DESCRIPTION
<!-- ALL PRs MUST BE RELATED TO AN OPEN ISSUE -->
closes #332


## What is included in this PR?

- Moves JavaRosa and OpenRosa under "Developing with ODK"
- Puts OpenRosa APIs TOC on the OpenRosa page. (BTW -- I think this solution would help with #105)

## What is left to be done?

I'd like to re-order the sidebar TOCs

