### PR TITLE
Added information on using command line to run the emulator 

### DIFF
--- a/contributing.rst
+++ b/contributing.rst
@@ -263,14 +263,6 @@ On Mac, add the following to your :file:`.bash_profile`
 
 .. help for linux and windows users here would be good...
 
-.. _standalone-sdk-tools:
-
-Standalone SDK Tools
-"""""""""""""""""""""""
-
-You can install the SDK Platform tools (including :command:`adb`) as a `standalone package <https://developer.android.com/studio/index.html#command-tools>`_. `This tutorial explains how to setup the standalone SDK tools <https://www.androidcentral.com/installing-android-sdk-windows-mac-and-linux-tutorial>`_.
-
-
 .. _docs-workflow-setup:
 
 Getting Ready to Work

--- a/projecting-collect.rst
+++ b/projecting-collect.rst
@@ -245,11 +245,11 @@ If the command is successfully executed, you will find your file in the launcher
 Using Command Line 
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-You can also run the emulator using command line. Follow the steps given below to start your emulator using command line:
+You can also run the emulator using command line. Follow the steps given below to start your emulator using the command line:
 
 .. note::
 
-  If SDK installation has been put in another drive or folder instead of in its default location of ``$USER_HOME`` or ``$HOME``. Make sure you haves set the environment variables according to that. In the command line type the following command to set environment variables.
+  If SDK installation has been put in another drive or folder instead of in its default location of ``$USER_HOME`` or ``$HOME``. Make sure you have set the environment variables according to that. In the command line type the following command to set environment variables.
   
   .. code-block:: console
   

--- a/projecting-collect.rst
+++ b/projecting-collect.rst
@@ -115,6 +115,7 @@ Follow the instructions given below to use Vysor:
 .. image:: /img/project-collect/collect-app.*
   :alt: Image showing collect-app after launching vysor
 
+.. _using-android-studio:
 
 Using Android Studio
 ----------------------------
@@ -200,7 +201,7 @@ Follow the procedures given below to run your app on the emulator:
 
 .. image:: /img/project-collect/emulator-screen1.*
   :alt: Image showing emulator screen.
-  
+   
 16. Now click on |SDK| to see the location of Android SDK.
 
 .. |SDK| image:: /img/project-collect/sdk-manager.*
@@ -239,7 +240,70 @@ If the command is successfully executed, you will find your file in the launcher
 .. image:: /img/project-collect/collect-emulator2.*
   :alt: Image showing collect app on the emulator screen
   
+.. _using-command-line:
+  
+Using Command Line 
+~~~~~~~~~~~~~~~~~~~~~~~
+
+You can also run the emulator using command line. Follow the steps given below to start your emulator using command line:
+
+.. note::
+
+  If SDK installation has been put in another drive or folder instead of in its default location of ``$USER_HOME`` or ``$HOME``. Make sure you haves set the environment variables according to that. In the command line type the following command to set environment variables.
+  
+  .. code-block:: console
+  
+    set ANDROID_SDK_ROOT=path\sdk\
+
+
+1. Open the terminal and move to the :file:`emulator` folder of the `SDK` directory.
+
+.. code-block:: console
+
+  $ cd emulator
+  
+2. For the list of available virtual devices, type the following command:
+
+.. code-block:: console
+
+  $ emulator -list-avds
+ 
+.. tip::
+
+  If you are not able to locate :file:`emulator.exe` file in :file:`SDK` folder. Type the following command to know the location of the file:
+  
+  .. code-block:: console
+
+    $ which emulator
+  
+  On Windows:
+  
+  .. code-block:: doscon
+
+    > where emulator
+
+3. Use :command:`emulator` to start the emulator. Here *avd_name* is the name of Android virtual device that you have created.
+
+.. code-block:: console
+
+  emulator -avd avd_name
+
+.. note::
+  
+  - You can use :command:`sdkmanager` command to update, install, and uninstall packages for the Android SDK. This method is not recommended as it is not user-friendly and also takes time.
+
+  .. code-block:: console
+
+   sdkmanager packages [options]
+   (e.g sdkmanager --verbose "system-images;android-19;google_apis;x86")
+  
+  - To create and manage Android Virtual device from the command line, you can use :command:`avdmanager`.
+  
+  .. code-block:: console
+
+   avdmanager [global options] command [command options]
+   (e.g avdmanager -v create avd --name testAVD -k "system-images;android-19;google_apis;x86" -g "google_apis")
+  
 .. seealso::
 
   You can also use `Genymotion <https://www.genymotion.com/>`_ as an alternative as it is very fast as compared to custom android emulators. It is also easy to use and configure, and it is available free of cost for personal use.
-  

--- a/projecting-collect.rst
+++ b/projecting-collect.rst
@@ -286,24 +286,37 @@ You can also run the emulator using command line. Follow the steps given below t
 
 .. code-block:: console
 
-  emulator -avd avd_name
+  $ emulator -avd avd_name
 
 .. note::
   
-  - You can use :command:`sdkmanager` command to update, install, and uninstall packages for the Android SDK. This method is not recommended as it is not user-friendly and also takes time.
+  1. You can use :command:`sdkmanager` command to update, install, and uninstall packages for the Android SDK. This method is not recommended as it is not   user-friendly and also takes time.
 
-  .. code-block:: console
+     To create an emualtor you need to download system image for a particular API level.
+	
+    .. code-block:: console
 
-   sdkmanager packages [options]
-   (e.g sdkmanager --verbose "system-images;android-19;google_apis;x86")
+      $ sdkmanager --verbose "system-images;android-19;google_apis;x86"
+	  
+	  
+    - The :option:`--verbose` option or :option:`-v` option shows errors, warnings and all messages.
+    - ``system-images;android-19;google_apis`` specifies the system image package for the Android virtual device.
+    - ``android-19`` specifies the API level. You can choose different API level if you want.
+   
+  2. To create and manage Android Virtual device from the command line, you can use :command:`avdmanager`.
   
-  - To create and manage Android Virtual device from the command line, you can use :command:`avdmanager`.
-  
-  .. code-block:: console
+     After downloading system image, you can use the following command to create an emulator.
+   
+    .. code-block:: console
 
-   avdmanager [global options] command [command options]
-   (e.g avdmanager -v create avd --name testAVD -k "system-images;android-19;google_apis;x86" -g "google_apis")
-  
+      $ avdmanager -v create avd --name testAVD -k "system-images;android-19;google_apis;x86" -g "google_apis"
+	  
+	 
+    - The :option:`create avd` option creates a new Android virtual device.
+    - :option:`--name` option is a **required** option which is used to specify name of the AVD. Here, the name of the AVD is testAVD.
+    - The :option:`-g` specifies the sys-img tag to use for the AVD.
+    - :option:`-k` specifies package path of the system image for the AVD.
+   
 .. seealso::
 
   You can also use `Genymotion <https://www.genymotion.com/>`_ as an alternative as it is very fast as compared to custom android emulators. It is also easy to use and configure, and it is available free of cost for personal use.


### PR DESCRIPTION
## What is included in this PR?
Added information on using the command line to run the emulator and removed outdated information as standalone SDK no longer includes adb.