### PR TITLE
Fixed location of media in form-widgets.rst

### DIFF
--- a/form-widgets.rst
+++ b/form-widgets.rst
@@ -2540,4 +2540,4 @@ XForm XML
 Including Images as Choices
 =============================
 
-To include images as choices for select questions, specify the file name in the **choices** worksheet, in a column labeled :th:`media::image`. The media files must be uploaded to the Android device in the :file:`/sdcard/odk/forms/` directory, in a file labeled :file:`{form-name}-files`. When uploading a form to ODK Aggregate, a second upload prompt will allow you to upload your files directory.
+To include images as choices for select questions, specify the file name in the **choices** worksheet, in a column labeled :th:`media::image`. The media files must be uploaded to the Android device in the :file:`/sdcard/odk/forms/` directory, in a folder labeled :file:`{form-name}-media`. When uploading a form to ODK Aggregate, a second upload prompt will allow you to upload your files directory.


### PR DESCRIPTION
closes #296 

## What is included in this PR?
Changed media location in form-widgets.rst to a folder labeled ``form-name-media``
