### PR TITLE
replaces random id with incremented id

### DIFF
--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -1,9 +1,3 @@
-// Autogen unique ids
-
-function uniqId() {
-  return Math.round(new Date().getTime() + (Math.random() * 100));
-}
-
 // Implement Details-like hide/show on class "details"
 
 $(function(){
@@ -14,8 +8,9 @@ $(function(){
 	)
     });
     // Add a toggler to each details element.
+    var id = 1000000
     $(".details").each(function(index){
-	id = uniqId();
+	id = id + 1;
 	$(this).attr('id', id);
 	togl = "<span class='toggler hiding' data-toggle='" + id + "'></span><br>";
 	$(this).before(togl);


### PR DESCRIPTION
This is a *hot fix* for a bug I discovered while testing a PR with a lot of details blocks.

The details blocks relied on a random-generated id. However, this was prone to collisions. This caused some panels to simply not open when toggled.

The solution here is to use a simple incrementing id. This has the added benefit of running faster.