### PR TITLE
Java 7 is no longer supported in CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           name: Install deploy requirements
           command: |
               if [[ "$CIRCLE_PROJECT_USERNAME" == "opendatakit" ]]; then \
-                sudo apt-get install -y openjdk-7-jre-headless
+                sudo apt-get install -y openjdk-8-jre-headless
                 gem install s3_website && s3_website install
               fi
       - run:


### PR DESCRIPTION
Fixes broken build. 

I tested this by SSHing into the failed machine and confirming that `openjdk-7-jre-headless` was no longer available in the `circleci/ruby:latest` docker image.

I then tried `openjdk-8-jre-headless` which installed, and then I successfully ran the follow on commands:
* `gem install s3_website && s3_website install`
* `s3_website push`