### PR TITLE
Remove hash redirects because they are not supported on S3

### DIFF
--- a/contributing.rst
+++ b/contributing.rst
@@ -524,14 +524,14 @@ Complete the pull request. The maintainers will review it as quickly as possible
 
    If you happen to rename any document file(:file:`*.rst`), then be sure that you add the redirect in your PR.
 
-   To add the redirect go to :file:`s3_website.yml` and uncomment the **redirects:** line. Add a mapping from the old file name to the new file name below the **redirects:** line, one mapping per line. Several examples of how to format these are shown in the comments.
+   To add the redirect go to :file:`s3_website.yml`. Add a mapping from the old file name to the new file name below the **redirects:** line, one mapping per line. Several examples of how to format these are shown in the file.
 
    For example you rename a file to :file:`newcheck.rst` from :file:`oldcheck.rst`, then to add the redirect:
 
    .. code-block:: yaml
 
      redirects:
-      /oldcheck: /newcheck
+      oldcheck/index.html: /newcheck
 
 
 .. _keep-working-the-docs:

--- a/s3_website.yml
+++ b/s3_website.yml
@@ -27,23 +27,8 @@ cloudfront_distribution_config:
 cloudfront_wildcard_invalidation: true
 
 redirects:
-  collect-install/#connecting-to-a-server: collect-connect
-  collect-install#connecting-to-a-server: collect-connect
-  collect-guide: collect-intro
-  collect-install/#connecting-to-your-own-odk-aggregate-server: collect-connect-aggregate
-  collect-install/#connecting-to-a-googe-drive-account: collect-connect-google
-  collect-install/#connecting-to-another-server-app: collect-connect/#other-options
-  collect-forms/#filling-out-forms: collect-filling-forms/
-  collect-integrations: launch-apps-from-collect/
-  aggregate-install/#installing-on-app-engine: aggregate-app-engine
-  aggregate-install/#installing-on-tomcat-local-or-cloud: aggregate-tomcat
-  aggregate-install/#installing-on-aws-cloud: aggregate-aws
-  aggregate-install/#installing-vm-local-or-cloud: aggregate-vm
-  aggregate-use/#data-transfer-using-aggregate: aggregate-data-access
-  aggregate-use/#help-options: aggregate-help
-  aggregate-use/#site-admin: aggregate-admin
-  aggregate-use/#submissions: aggregate-data
-  aggregate-use/#form-manage: form-management
-  aggregate-guide/: aggregate-intro
-  visualize/: aggregate-visualize
-  aggregate-app-engine/#increasing-app-engine-server-size-can-improve-performance-and-reduce-data-corruption: aggregate-increase-aws-size
+  # use url/index.html syntax to enable url, url/, url/index.html and hash passthrough
+  aggregate-guide/index.html: /aggregate-intro
+  collect-guide/index.html: /collect-intro
+  collect-integrations/index.html: /launch-apps-from-collect
+  visualize/index.html: /aggregate-visualize


### PR DESCRIPTION
Fixes #425 
Fixes #426 
Fixes #414

In [my research](https://stackoverflow.com/a/15133106/152938), I have learned that URL fragments (the stuff after the hash/bang) does not get sent to the server. Because of this, S3 (and probably any other service that would rewrite URLs) cannot redirect based on the hash. 

You could do the [redirect with JavaScript](https://stackoverflow.com/a/24377443/152938), but that feels hacky.

I confirmed the above by testing all the various combinations of urls (e.g., `collect-install/#connecting-to-a-server`, `collect-install#connecting-to-a-server`) to see if I could get a redirect working. I could not.

I verified this change by testing on my own S3-based static website and confirming that the url/index.html syntax redirect when I type `url`, `url/`, `url/index.html` and hash passthroughs.

As far as implications for design, I guess we should be really careful about using anchors.