### PR TITLE
Aggregate fixes

### DIFF
--- a/aggregate-admin.rst
+++ b/aggregate-admin.rst
@@ -1,5 +1,5 @@
-Aggregate Admin
-=====================
+Administering Aggregate
+===========================
 
 Click the :guilabel:`Log In` link in the upper right corner of the screen to be presented with the Log onto Aggregate screen. Choose the :guilabel:`Sign in with Aggregate password` button and enter the super-user username you specified within the installer. The initial password for this account is `aggregate`. When you log in, :guilabel:`Site Admin` will be visible to you.
 

--- a/aggregate-best-practices.rst
+++ b/aggregate-best-practices.rst
@@ -1,0 +1,8 @@
+Tips and Best Practices
+============================
+
+.. toctree::
+  :maxdepth: 2
+  
+  aggregate-limitations
+  aggregate-boost-performance 

--- a/aggregate-best-practices.rst
+++ b/aggregate-best-practices.rst
@@ -3,6 +3,7 @@ Tips and Best Practices
 
 .. toctree::
   :maxdepth: 2
-  
+
+  form-uploader  
   aggregate-limitations
   aggregate-boost-performance 

--- a/aggregate-data-access.rst
+++ b/aggregate-data-access.rst
@@ -1,4 +1,4 @@
-Data Transfer using Aggregate
+Getting Data Out of Aggregate
 ================================
 
 ODK Aggregate supports three primary mechanisms for data transfer:

--- a/aggregate-forms.rst
+++ b/aggregate-forms.rst
@@ -1,5 +1,5 @@
-Form Management
-==================
+Managing Forms in Aggregate
+================================
 
 You can add, download and delete forms, export data into useful formats, publish data into another service, manually upload submissions and view the published data. ODK Aggregate provides all these options under the :guilabel:`Form Management` tab.
 

--- a/aggregate-setup.rst
+++ b/aggregate-setup.rst
@@ -13,4 +13,4 @@ Setting Up ODK Aggregate
   aggregate-install
   aggregate-upgrade
   aggregate-backup
-  aggregate-boost-performance
+

--- a/aggregate-tomcat.rst
+++ b/aggregate-tomcat.rst
@@ -49,6 +49,25 @@ Encrypted forms can be used in conjuction with either of the first two suggestio
 
 If you are not using encrypted forms and are handling sensitive data, a computer security specialist should review your system and your security procedures. 
 
+Database Systems
+~~~~~~~~~~~~~~~~~~
+
+ODK Aggregate works with any of these database servers:
+
+- MySQL
+- PostgreSQL
+- Microsoft SQL Server
+- Azure SQL Server
+
+Most deployments will use either MySQL or PostgreSQL, as they are the two most prevalent open source relational database servers.
+
+MySQL is the most popular, so you will likely find more qualified professionals to install, administer, and debug it. However, you should consider PostgreSQL if you plan to:
+
+- collect geographic data
+- use forms with a very high number of questions (over 200)
+
+PostgreSQL has better built-in support for geographic data, and MySQL's table have a row size limit that will affect perfromance for very large forms.  
+
 .. note::
 
   Use of an SSL and `https` is recommended for any deployment accessed from the internet.

--- a/aggregate-tomcat.rst
+++ b/aggregate-tomcat.rst
@@ -66,7 +66,7 @@ MySQL is the most popular, so you will likely find more qualified professionals 
 - collect geographic data
 - use forms with a very high number of questions (over 200)
 
-PostgreSQL has better built-in support for geographic data, and MySQL's table have a row size limit that will affect perfromance for very large forms.  
+PostgreSQL has better built-in support for geographic data, and MySQL's tables have a row size limit that will affect performance for very large forms.  
 
 .. note::
 

--- a/aggregate-use.rst
+++ b/aggregate-use.rst
@@ -9,5 +9,4 @@ Using ODK Aggregate
   aggregate-admin
   aggregate-data-access
   aggregate-visualize
-  form-uploader
   aggregate-help

--- a/index.rst
+++ b/index.rst
@@ -52,7 +52,7 @@ For a complete list of our projects, check out `Open Data Kit on Github <https:/
   aggregate-intro
   aggregate-setup
   aggregate-use
-  aggregate-limitations
+  aggregate-best-practices
 
 .. toctree::
   :hidden:


### PR DESCRIPTION
closes #440
addresses #398 


## What is included in this PR?

 - Moved the TOCs around a little to better match what we did with collect
 - Updated titles to used gerund verbs wherever appropriate
 - added a mention of the MySQL table row width problem


## What is left to be done in the addressed issue?

It might be worthwhile to expand the section I added about choosing a database into a larger document about pros/cons etc. of different RDBMSes. But... it might not be. The information I wrote there covered the problem identified in #440, but it doesn't really mention any other concerns.

## What problems did you encounter?


### Titling... verbs vs. nouns; different verb cases

I don't like any solution to the question of consistent titling. I prefer gerunds for a lot of reasons, and that's what we've settled on for this repo. But then sometimes they seem like the weirdest possible way to write a title (like `Administering Aggregate` rather than `Aggregate Admin`, for example). 

A different verb form doesn't solve the problem. Whatever the advantages or disadvantages of imperative ("Install the thing") or infinitive ("How to install") over our chosen gerun ("Installing"), sometimes a verb just doesn't seem quite right -- like a page about "Form Uploader", for example. This is fine at the point of titling a single page, but then sometimes you end up with TOCs that have a list of titles with wildly divergent grammar forms.

I have done my best to end up at a place that seems as reasonable as possible. But I'm open to specific and concrete suggestions.