### PR TITLE
fixes show details labels

### DIFF
--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -15,6 +15,7 @@ $(function(){
 	togl = "<span class='toggler hiding' data-toggle='" + id + "'></span><br>";
 	$(this).before(togl);
 	$(this).addClass('hidden');
+	$(this).has("img:only-child").addClass('screenshot-only');
     });
 
     // Add class to list items that include togglers
@@ -26,20 +27,35 @@ $(function(){
     // Define the toggler labels
     hiding_label = "[<span class='toggle-sign'>&plus;</span>] show details";
     showing_label = "[<span class='toggle-sign'>&minus;</span>] hide details";
+    ss_hiding_label = "[<span class='toggle-sign'>&plus;</span>] show screenshot";
+    ss_showing_label = "[<span class='toggle-sign'>&minus;</span>] hide screenshot";
+
 
     // Add labels and onclick function to togglers
     $(".toggler").each(function(index){
-	$(this).html(hiding_label);
+	if ($(this).siblings().hasClass('screenshot-only')) {
+	    $(this).html(ss_hiding_label);
+	} else {
+	    $(this).html(hiding_label);
+	}
 	$(this).click(function(e){
 	    toggle_image = $('#' + $(this).attr('data-toggle'));
 	    if ($(this).hasClass('hiding')) {
-		$(this).html(showing_label);
 		$(this).removeClass('hiding');
 		toggle_image.removeClass("hidden");
+		if ($(this).siblings().hasClass('screenshot-only')) {
+		    $(this).html(ss_showing_label);
+		} else {
+		    $(this).html(showing_label);
+		}
 	    } else {
-		$(this).html(hiding_label);
 		$(this).addClass('hiding');
 		toggle_image.addClass("hidden");
+		if ($(this).siblings().hasClass('screenshot-only')) {
+		    $(this).html(ss_hiding_label);
+		} else {
+		    $(this).html(hiding_label);
+		}
 	    }
 	})
     });    

--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -16,6 +16,9 @@ $(function(){
 	$(this).before(togl);
 	$(this).addClass('hidden');
 	$(this).has("img:only-child").addClass('screenshot-only');
+	if ( $(this).is("img") ) {
+	    $(this).addClass("screenshot-only");
+	}
     });
 
     // Add class to list items that include togglers


### PR DESCRIPTION
closes #448

If a details block only contains a screenshot, the show/hide label says "Screenshot" instead of "Details"

## What new work does this PR create?

Now that so many labels on some pages say "show screenshot," it isn't clear why the other screenshots are displayed by default. This will take some thought as I work through editing for style.