### PR TITLE
Enables testing only on changed files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,9 @@ jobs:
             sudo pip install -r requirements.txt
       - run:
           name: Style Guide Testing
-          command: sudo python style-test.py  
+          command: |
+            paths=$(git diff origin/master... --name-only)
+            sudo python style-test.py $paths
       - run:
           name: Build docs
           command: sphinx-build -W -b dirhtml . build

--- a/style-test.py
+++ b/style-test.py
@@ -214,7 +214,7 @@ def get_paths(paths):
     # Add paths if provided by user
     if paths:
         search_path = search_path + "/"
-        path_list = [search_path + path for path in paths]
+        path_list = [search_path + path for path in paths if '.rst' in path]
 
     # Add all rst files if specific paths not provided by user
     else:


### PR DESCRIPTION
closes #493 

## What is included in this PR?
Style testing is only performed on changed files by using command ``git diff origin/master... --name-only`` to generate changed file list.