### PR TITLE
Fix search path for style guide testing

### DIFF
--- a/style-test.py
+++ b/style-test.py
@@ -25,7 +25,8 @@ t = Terminal()
 
 def add_checks():      
     """Add checks to proselint."""
-    src ='./style-guide'       
+    file_path = os.path.realpath(__file__)
+    src = file_path[0:file_path.rfind('/')] + '/style-guide'
     dest = os.path.dirname(proselint.__file__)
     dest_prc = dest + '/.proselintrc'
     dest = dest + '/checks/style-guide'
@@ -206,7 +207,7 @@ def get_paths(paths):
     file_path = os.path.realpath(__file__)
 
     # find path for all .rst files
-    search_path = file_path[0:file_path.rfind('/')]
+    search_path = file_path[0:file_path.rfind('/')] + "/src"
 
     # Make a list of paths to check for
     path_list = []
@@ -214,6 +215,7 @@ def get_paths(paths):
     # Add paths if provided by user
     if paths:
         search_path = search_path + "/"
+        paths = [path[path.rfind('/')+1:] for path in paths]
         path_list = [search_path + path for path in paths if '.rst' in path]
 
     # Add all rst files if specific paths not provided by user
@@ -221,7 +223,10 @@ def get_paths(paths):
         for filename in glob.glob(os.path.join(search_path, '*.rst')):
             path_list.append(filename)
 
-    path_list = [path for path in path_list if os.path.isfile(path)]             
+    path_list = [path for path in path_list if os.path.isfile(path)]
+
+    if not path_list:
+        print("No files to check for!")            
     
     return path_list
 
@@ -233,8 +238,6 @@ def get_changed_files():
     repo = git.Repo(repo_path)
     changedFiles = [item.a_path for item in repo.index.diff(None)]
     changedFiles += repo.untracked_files
-    changedFiles = [f for f in changedFiles if ".rst" in f
-                     and os.path.isfile(repo_path + "/" + f)]
     changedFiles = tuple(changedFiles)
     return changedFiles
 
@@ -277,7 +280,7 @@ def run_checks(paths, disp, fix):
         
         # display the result of checks
         if disp:
-            disp_checks(errors, shortname)
+            disp_checks(errors, filename, shortname)
         
         # list to hold fixable errors
         fix_list = []
@@ -319,23 +322,23 @@ def run_checks(paths, disp, fix):
         disp_cnt()
 
 
-def disp_checks(errors, filename):
+def disp_checks(errors, filename, shortname):
     """Display errors and warnings."""
     global err_cnt
     global warn_cnt
     global t
     list_errors = get_errlist()
-
+    
     for e in errors:        
         # e[0]=check
         # Set warning or error severity
         # Don't set errors for style-guide as they might be examples
-        if e[0] in list_errors and "style-guide.rst" not in filename:
+        if e[0] in list_errors and "style-guide.rst" not in shortname:
             severity = "error"
         else:
             severity = "warning" 
         # e[2]+1=line, e[3]+1=col
-        line1 = "%s | line: %d | col: %d" %(filename, e[2]+1, e[3]+1)
+        line1 = "%s | line: %d | col: %d" %(shortname, e[2]+1, e[3]+1)
         # get line from file where  e[2]+1=line, e[3]+1=col
         line2 = get_line(filename,e[2]+1,e[3]+1)
         # e[1]=error_message
@@ -405,6 +408,7 @@ def gen_out(path):
         for e in err_list:
             csv_out.writerow(e)    
 
+
 def gen_list(paths = None):
     """Return a list of errors and warnings."""
     global err_list
@@ -444,10 +448,7 @@ def style_test(in_path = None, out_path = None, diff = None,
     # run the checks on docs
     disp = True
     if fix or out_path:
-        disp = False
-    if diff and not in_path:
-        print("No files to check for!")
-        return    
+        disp = False  
     run_checks(in_path, disp, fix)
 
     # generate output


### PR DESCRIPTION
closes #499 


## What is included in this PR?
Search path for style-test script is fixed to check for ``.rst`` files in the ``src`` directory.