### PR TITLE
removes curly quote transform

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 alabaster==0.7.10
 Babel==2.4.0
-docutils==0.13.1
+docutils>=0.14
 imagesize==0.7.1
 Jinja2==2.9.6
 MarkupSafe==1.0
@@ -9,7 +9,7 @@ pytz==2017.2
 requests==2.14.2
 six==1.10.0
 snowballstemmer==1.2.1
-Sphinx==1.6.1
+Sphinx==1.6.6
 sphinx-rtd-theme==0.2.4
 sphinxcontrib-websupport==1.0.1
 typing==3.6.1

--- a/src/aggregate-intro.rst
+++ b/src/aggregate-intro.rst
@@ -12,4 +12,3 @@ ODK Aggregate is a server application and data repository used with :doc:`collec
 - :doc:`Export and publish data in a variety of formats <aggregate-data-access>`
 
 
-

--- a/src/aggregate-intro.rst
+++ b/src/aggregate-intro.rst
@@ -1,14 +1,12 @@
+******************
 ODK Aggregate
-================
+******************
 
 .. _aggregate-introduction:
 
-:dfn:`ODK Aggregate` is an open source Java application that
-stores, analyses, and presents :doc:`XForm <form-design-intro>` survey data collected using :doc:`collect-intro` or other :doc:`OpenRosa-compliant applications <openrosa>` to:
+ODK Aggregate is a server application and data repository used with :doc:`collect-intro` or other :doc:`OpenRosa-compliant data client applications <openrosa>` to:
 
 - :doc:`Host <aggregate-forms>` blank :doc:`XForms <form-design-intro>` used by ODK Collect or other OpenRosa clients
 - :doc:`Store and manage XForm submission data <aggregate-data>` 
 - Visualize collected data using :doc:`maps <aggregate-visualize>` and :ref:`simple graphs <visualize-submissions>`
 - :doc:`Export and publish data in a variety of formats <aggregate-data-access>`
-
-

--- a/src/aggregate-intro.rst
+++ b/src/aggregate-intro.rst
@@ -10,3 +10,6 @@ ODK Aggregate is a server application and data repository used with :doc:`collec
 - :doc:`Store and manage XForm submission data <aggregate-data>` 
 - Visualize collected data using :doc:`maps <aggregate-visualize>` and :ref:`simple graphs <visualize-submissions>`
 - :doc:`Export and publish data in a variety of formats <aggregate-data-access>`
+
+
+

--- a/src/aggregate-intro.rst
+++ b/src/aggregate-intro.rst
@@ -1,10 +1,10 @@
-******************
 ODK Aggregate
-******************
+================
 
 .. _aggregate-introduction:
 
-ODK Aggregate is a server application and data repository used with :doc:`collect-intro` or other :doc:`OpenRosa-compliant data client applications <openrosa>` to:
+:dfn:`ODK Aggregate` is an open source Java application that
+stores, analyses, and presents :doc:`XForm <form-design-intro>` survey data collected using :doc:`collect-intro` or other :doc:`OpenRosa-compliant applications <openrosa>` to:
 
 - :doc:`Host <aggregate-forms>` blank :doc:`XForms <form-design-intro>` used by ODK Collect or other OpenRosa clients
 - :doc:`Store and manage XForm submission data <aggregate-data>` 

--- a/src/conf.py
+++ b/src/conf.py
@@ -87,6 +87,9 @@ todo_include_todos = True
 # suppress warnings for unknown options
 suppress_warnings = ['ref.option']
 
+# Smart (q)uotes, (D)ashes, and (e)llipses
+smartquotes = True
+smartquotes_action = 'De'
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
closes #513 

## What is included in this PR?

 - `conf.py` is edited to make explicit the smartquotes option
     The transform is left ON for dashes and ellipses, but turned off for quotes
 - `requirements.txt` is updated, as the smartquotes options require later versions of Sphinx and docutils

## What problems did you encounter?

I would have preferred to only disable smartquotes within specific directives, 
as it is better to leave them on for normal prose.
But this would have required custom coding, I think,
as such an option does not currently exist.

(If this option is added in the future, we may want to consider it.)

### Updates to Sphinx and Docutils

The ability to specify options for the smartquotes parser was new in Sphinx 1.6.6,
prior to this PR, we are on 1.6.1

I *tried* updating to Sphinx 1.7, but this broke the custom directives.
If there is a reason in the future to upgrade past 1.6.x, we;ll need some debugging work.

In the end, I updated `requirements.txt` just to 1.6.6

