### PR TITLE
PDF output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,8 +63,9 @@ jobs:
               cd build/latex
               xelatex OpenDataKit.tex
               xelatex OpenDataKit.tex
-              cd ../..
-              cp build/latex/OpenDataKit.pdf build
+      - store_artifacts:
+          path: build/latex/OpenDataKit.pdf
+          destination: OpenDataKit.pdf
 
   deploy:
     working_directory: ~/work

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
           command: |
             sudo apt-get install pngquant
             sudo apt-get install python-enchant
+            sudo apt-get install texlive-xetex
             sudo pip install -r requirements.txt
       - run:
           name: Style Guide Testing
@@ -31,6 +32,16 @@ jobs:
           command: |
             sphinx-build -b spelling src build/spelling
             python util/check-spelling-output.py
+      - run:
+          name: Build PDF
+          command: |
+            sphinx-build -b latex src build/latex
+            sudo python util/resize.py
+            cd build/latex
+            xelatex OpenDataKit.tex
+            xelatex OpenDataKit.tex
+            cd ../..
+            sudo cp build/latex/OpenDataKit.pdf build
       - run:
           name: Build docs
           command: sphinx-build -W -b dirhtml src build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,7 @@ jobs:
             - build/*
             - s3_website.yml
   build_pdf:
+    working_directory: ~/work
     docker:
       - image: tianon/latex
     steps:
@@ -89,9 +90,13 @@ workflows:
   build_deploy:
     jobs:
       - build
+      - build_pdf:
+          requires:
+            - build
       - deploy:
           requires:
             - build
+            - build_pdf
           # We'd like to also filter by username and remove the if/fi above, but username filtering is not supported in CircleCI
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,9 +53,10 @@ jobs:
   build_pdf:
     working_directory: ~/work
     docker:
-      - image: tianon/latex
+      - image: schickling/latex
     steps:
-      - checkout
+      - attach_workspace:
+          at: ~/work
       - run:
           name: Build PDF
           command: |
@@ -63,7 +64,7 @@ jobs:
               xelatex OpenDataKit.tex
               xelatex OpenDataKit.tex
               cd ../..
-              sudo cp build/latex/OpenDataKit.pdf build
+              cp build/latex/OpenDataKit.pdf build
 
   deploy:
     working_directory: ~/work

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ jobs:
           command: |
             sudo apt-get install pngquant
             sudo apt-get install python-enchant
-            sudo apt-get install texlive-xetex
             sudo pip install -r requirements.txt
       - run:
           name: Style Guide Testing
@@ -37,11 +36,6 @@ jobs:
           command: |
             sphinx-build -b latex src build/latex
             sudo python util/resize.py
-            cd build/latex
-            xelatex OpenDataKit.tex
-            xelatex OpenDataKit.tex
-            cd ../..
-            sudo cp build/latex/OpenDataKit.pdf build
       - run:
           name: Build docs
           command: sphinx-build -W -b dirhtml src build
@@ -56,6 +50,20 @@ jobs:
           paths:
             - build/*
             - s3_website.yml
+  build_pdf:
+    docker:
+      - image: tianon/latex
+    steps:
+      - checkout
+      - run:
+          name: Build PDF
+          command: |
+              cd build/latex
+              xelatex OpenDataKit.tex
+              xelatex OpenDataKit.tex
+              cd ../..
+              sudo cp build/latex/OpenDataKit.pdf build
+
   deploy:
     working_directory: ~/work
     docker:

--- a/s3_website.yml
+++ b/s3_website.yml
@@ -14,6 +14,7 @@ exclude_from_upload:
   - .DS_Store
   - objects.inv
   - spelling
+  - latex
 
 cloudfront_distribution_id: E1IDKKW65Q2HVZ
 

--- a/src/_templates/footer.html
+++ b/src/_templates/footer.html
@@ -11,7 +11,7 @@
   {% endif %}
 
   <hr/>
-  <p class="footerText"> {{ doc_pdf }} <a href="{{ odkpdf }}" download> {{ odkdocs }} </a></p>
+  <p class="footerText"> <a href="{{ odkpdf }}" download> {{ download_pdf }} </a></p>
   <p class="footerText"> {{ faq_help }} <a href="{{ forum_here }}"> {{ forum }} </a> </p>
   <p class="footerText"> {{ prob_in_doc }} <a href="{{ file_issue_here }}"> {{ file_issue }} </a> </p>
   <p class="footerText"> {{ contri_start }} <a href="{{ repo_here }}"> {{ fork_repo }} </a> {{ join }} <a href="{{ contri_guide }}"> {{ contri }} </a></p>

--- a/src/_templates/footer.html
+++ b/src/_templates/footer.html
@@ -11,6 +11,7 @@
   {% endif %}
 
   <hr/>
+  <p class="footerText"> {{ doc_pdf }} <a href="{{ odkpdf }}" download> {{ odkdocs }} </a></p>
   <p class="footerText"> {{ faq_help }} <a href="{{ forum_here }}"> {{ forum }} </a> </p>
   <p class="footerText"> {{ prob_in_doc }} <a href="{{ file_issue_here }}"> {{ file_issue }} </a> </p>
   <p class="footerText"> {{ contri_start }} <a href="{{ repo_here }}"> {{ fork_repo }} </a> {{ join }} <a href="{{ contri_guide }}"> {{ contri }} </a></p>

--- a/src/collect-filling-forms.rst
+++ b/src/collect-filling-forms.rst
@@ -43,7 +43,7 @@ Questions with response choices can be answered by touching the selected items. 
 
   Radio buttons accept one selection.
   
-.. figure:: /img/collect-completing-forms/multi-select.gif 
+.. figure:: /img/collect-completing-forms/multi-select.*
   :alt: A question screen with check boxes (multi-select).
   
   Check boxes accept multiple answers.
@@ -82,7 +82,7 @@ Removing answers
 
 To remove a response, :gesture:`Long Press` on the :term:`question label`. 
 
-.. image:: /img/collect-completing-forms/long-press-to-remove.gif 
+.. image:: /img/collect-completing-forms/long-press-to-remove.*
   :alt: To remove an answer to a question, long press the question label and follow the on-screen prompts.
   :class: details
 
@@ -238,7 +238,7 @@ Name the form
 
 The last form screen provides a default name for the form (defined by the form designer). You can rename it. This name only applies to that particular instance of a completed form (not to the blank form).
 
-.. image:: /img/collect-completing-forms/rename-form.gif 
+.. image:: /img/collect-completing-forms/rename-form.*
   :alt: To rename the form instance, touch the form name in the last screen of the survey.
   
 The Form Name identifies the form in lists throughout the app. For this reason, a meaningful name may be important to you. After you've saved the name, the form automatically moves to the :guilabel:`Send Finalized Form` section, from where you can send it.

--- a/src/conf.py
+++ b/src/conf.py
@@ -96,6 +96,15 @@ smartquotes_action = 'De'
 # Print suggestions for misspelled words.
 spelling_show_suggestions = True
 
+# Change image preference for DirectoryHTMLBuilder
+from sphinx.builders.html import DirectoryHTMLBuilder
+DirectoryHTMLBuilder.supported_image_types = [
+    'image/svg+xml',
+    'image/gif',
+    'image/png',
+    'image/jpeg'
+]
+
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -138,20 +147,27 @@ htmlhelp_basename = 'OpenDataKitdoc'
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
-    #
-    # 'papersize': 'letterpaper',
+    'papersize': 'letterpaper',
 
     # The font size ('10pt', '11pt' or '12pt').
-    #
-    # 'pointsize': '10pt',
+    'pointsize': '12pt',
 
     # Additional stuff for the LaTeX preamble.
-    #
-    # 'preamble': '',
+    'preamble': '''
+    \usepackage{fontspec}
+    ''',
+
+    # disable font inclusion
+    'fontpkg': '',
+    'fontenc': '',
+
+    # Fix Unicode handling by disabling the defaults for a few items
+    # set by sphinx
+    'inputenc': '',
+    'utf8extra': '',
 
     # Latex figure (float) alignment
-    #
-    # 'figure_align': 'htbp',
+    'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
@@ -234,6 +250,21 @@ rst_prolog="""
 """
 
 # At bottom of every document
+doc_pdf = """
+
+You can also the download the PDF for the
+
+"""
+odkdocs = """
+
+ODK Docs
+
+"""
+odkpdf = """
+
+../OpenDataKit.pdf
+
+"""
 prob_in_doc = """
 
 If you find a problem with this documentation, please 
@@ -311,7 +342,10 @@ rst_epilog = """
 
 """
 
-html_context = {'prob_in_doc' : prob_in_doc , 
+html_context = {'doc_pdf' : doc_pdf,
+                'odkdocs' : odkdocs,
+                'odkpdf' : odkpdf,
+                'prob_in_doc' : prob_in_doc ,
                 'contri_start' : contri_start , 
                 'join' : join , 
                 'faq_help' : faq_help , 

--- a/src/conf.py
+++ b/src/conf.py
@@ -250,14 +250,9 @@ rst_prolog="""
 """
 
 # At bottom of every document
-doc_pdf = """
+download_pdf = """
 
-You can also the download the PDF for the
-
-"""
-odkdocs = """
-
-ODK Docs
+Download this documentation as a PDF.
 
 """
 odkpdf = """
@@ -342,8 +337,7 @@ rst_epilog = """
 
 """
 
-html_context = {'doc_pdf' : doc_pdf,
-                'odkdocs' : odkdocs,
+html_context = {'download_pdf' : download_pdf,
                 'odkpdf' : odkpdf,
                 'prob_in_doc' : prob_in_doc ,
                 'contri_start' : contri_start , 

--- a/src/img/collect-completing-forms/long-press-to-remove.png
+++ b/src/img/collect-completing-forms/long-press-to-remove.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cc194f8d390ef5b8b91a97fb90b23b86b93aa39d7e64ef7896101a74aa5d489c
-size 74496
+oid sha256:befe3abc2cb33c87a28c5ca4fd020a6388ae3f91948a308658cc09941190ed03
+size 92971

--- a/src/img/collect-completing-forms/multi-select.png
+++ b/src/img/collect-completing-forms/multi-select.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b2909bfb3b6153af398aab3f2dc630ecc615b934d77a9d5d966c4dd2b07579e
+size 100155

--- a/src/img/collect-completing-forms/rename-form.png
+++ b/src/img/collect-completing-forms/rename-form.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78aea2e8f991ddec1dc38ea432bf87647a244d3a8fe76089e0c7609694f581eb
+size 100357

--- a/util/resize.py
+++ b/util/resize.py
@@ -8,7 +8,7 @@ def single_resize(imagedir, filename):
     filepath = os.path.join(imagedir, filename)
     image = Image.open(filepath)
     old_w, old_h  = image.size
-    h = min(old_h, 500)
+    h = min(old_h, 300)
     w = (int)(old_w * h / old_h)
     image = image.resize((w,h), Image.ANTIALIAS)
     image.save(filepath, quality=95)

--- a/util/resize.py
+++ b/util/resize.py
@@ -1,0 +1,32 @@
+import os
+import sys
+from PIL import Image
+
+def single_resize(imagedir, filename):
+    """Resize a single image."""
+    print("Resisizing %s ..." %filename)
+    filepath = os.path.join(imagedir, filename)
+    image = Image.open(filepath)
+    old_w, old_h  = image.size
+    h = min(old_h, 500)
+    w = (int)(old_w * h / old_h)
+    image = image.resize((w,h), Image.ANTIALIAS)
+    image.save(filepath, quality=95)
+
+def bulk_resize(imagedir):
+    """Resize all images in a folder."""
+    imgexts = ["png", "jpeg", "jpg"]
+    for (path, dirs, files) in os.walk(imagedir):
+        for filename in files:
+            ext = filename[-3:].lower()
+            ext_j = filename[-4:].lower()
+            if ext not in imgexts and ext_j not in imgexts:
+                continue
+
+            single_resize(path, filename)
+
+file_path = os.path.realpath(__file__)
+subdir_path = file_path[0:file_path.rfind('/')]
+dir_path = subdir_path[0:subdir_path.rfind('/')]
+imagedir = dir_path + "/build/latex"
+bulk_resize(imagedir)


### PR DESCRIPTION
closes #271 


## What is included in this PR?
- Added pdf output generation
- Changed image ordering for html builder to choose gif over png
- Added png images as substitutes for gif for latex builder
- Script to resize images

## What is left to be done in the addressed issue?
- Large tables are not rendered properly

## What problems did you encounter?
- There are still some underfull and overfull issues.
- We need to run xelatex engine twice

EDIT: The first commit needs to be dropped once #536 is merged!