### PR TITLE
Fix pdf download

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,8 @@ jobs:
               cd build/latex
               xelatex OpenDataKit.tex
               xelatex OpenDataKit.tex
+              cd ../..
+              cp build/latex/OpenDataKit.pdf build/OpenDataKit.pdf
       - store_artifacts:
           path: build/latex/OpenDataKit.pdf
           destination: OpenDataKit.pdf


### PR DESCRIPTION
closes #561 


## What is included in this PR?
PDF is copied over to build directory after generation so that the file is available for download. I have tested this locally and it works fine!