### PR TITLE
Try fixing pdf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,8 @@ jobs:
               cd ../..
               cp build/latex/OpenDataKit.pdf build/OpenDataKit.pdf
       - store_artifacts:
-          path: build/latex/OpenDataKit.pdf
-          destination: OpenDataKit.pdf
+          path: build/OpenDataKit.pdf
+          destination: build/OpenDataKit.pdf
 
   deploy:
     working_directory: ~/work


### PR DESCRIPTION
addresses  #561 


## What is included in this PR?
The pdf should be stored in build directory. I am still unable to figure out the issue completely but I think the way artifacts are uploaded is different in both the cases. 

@adammichaelwood @yanokwa  Can you please guide me here!