### PR TITLE
Fix PDF links

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,12 +63,14 @@ jobs:
               cd build/latex
               xelatex OpenDataKit.tex
               xelatex OpenDataKit.tex
-              cd ../..
-              cp build/latex/OpenDataKit.pdf build/OpenDataKit.pdf
+              mv OpenDataKit.pdf ../downloads/ODK-Documentation.pdf
       - store_artifacts:
-          path: build/latex/OpenDataKit.pdf
-          destination: OpenDataKit.pdf
-
+          path: build/downloads/ODK-Documentation.pdf
+          destination: ODK-Documentation.pdf
+      - persist_to_workspace:
+          root: ~/work
+          paths:
+            - build/*
   deploy:
     working_directory: ~/work
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,9 +63,9 @@ jobs:
               cd build/latex
               xelatex OpenDataKit.tex
               xelatex OpenDataKit.tex
-              mv OpenDataKit.pdf ../downloads/ODK-Documentation.pdf
+              mv OpenDataKit.pdf ../_downloads/ODK-Documentation.pdf
       - store_artifacts:
-          path: build/downloads/ODK-Documentation.pdf
+          path: build/_downloads/ODK-Documentation.pdf
           destination: ODK-Documentation.pdf
       - persist_to_workspace:
           root: ~/work

--- a/src/_templates/footer.html
+++ b/src/_templates/footer.html
@@ -11,7 +11,7 @@
   {% endif %}
 
   <hr/>
-  <p class="footerText"> <a href="{{ odkpdf }}" download> {{ download_pdf }} </a></p>
+  <p class="footerText"> <a href="{{ odk_pdf }}" download> {{ download_pdf }} </a></p>
   <p class="footerText"> {{ faq_help }} <a href="{{ forum_here }}"> {{ forum }} </a> </p>
   <p class="footerText"> {{ prob_in_doc }} <a href="{{ file_issue_here }}"> {{ file_issue }} </a> </p>
   <p class="footerText"> {{ contri_start }} <a href="{{ repo_here }}"> {{ fork_repo }} </a> {{ join }} <a href="{{ contri_guide }}"> {{ contri }} </a></p>

--- a/src/conf.py
+++ b/src/conf.py
@@ -255,9 +255,9 @@ download_pdf = """
 Download this documentation as a PDF.
 
 """
-odkpdf = """
+odk_pdf = """
 
-../OpenDataKit.pdf
+../_downloads/ODK-Documentation.pdf
 
 """
 prob_in_doc = """
@@ -338,7 +338,7 @@ rst_epilog = """
 """
 
 html_context = {'download_pdf' : download_pdf,
-                'odkpdf' : odkpdf,
+                'odk_pdf' : odk_pdf,
                 'prob_in_doc' : prob_in_doc ,
                 'contri_start' : contri_start , 
                 'join' : join , 


### PR DESCRIPTION
This combines a few things.
* Renames the pdf to something a bit more sensible (ODK Documentation)
* Moves the PDF to downloads
* And persists the workspace so the deploy can find it. 

I'm not 100% sure the last bullet works, but there's only one way to try it.