### PR TITLE
Add soft clean to leave build folder intact for python server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,14 +27,22 @@ odk2_clean:
 	rm -rf $(COMPILE2_SRCDIR)
 	rm -rf $(ODK2_BUILDDIR)
 
+odk1_clean_files:
+	rm -rf $(COMPILE1_SRCDIR)
+	rm -rf $(ODK1_BUILDDIR)/*
+
+odk2_clean_files:
+	rm -rf $(COMPILE2_SRCDIR)
+	rm -rf $(ODK2_BUILDDIR)/*
+
 clean: odk1_clean odk2_clean
 
-odk1_copy: odk1_clean
+odk1_copy: odk1_clean_files
 	mkdir $(COMPILE1_SRCDIR)
 	cp -rf $(ODK1_SRCDIR)/* $(COMPILE1_SRCDIR)
 	cp -rf $(SHARED_SRCDIR)/* $(COMPILE1_SRCDIR)
 
-odk2_copy: odk2_clean
+odk2_copy: odk2_clean_files
 	mkdir $(COMPILE2_SRCDIR)
 	cp -rf $(ODK2_SRCDIR)/* $(COMPILE2_SRCDIR)
 	cp -rf $(SHARED_SRCDIR)/* $(COMPILE2_SRCDIR)


### PR DESCRIPTION
<!-- ALL PRs MUST BE RELATED TO AN OPEN ISSUE -->
closes https://github.com/opendatakit/docs/issues/578

## What is included in this PR?
Updates Makefile with new soft clean task that will leave the odkX-build directory intact when running `make odkX`. This is useful so that you can leave your python server running and not need to restart it each time you recompile.
