### PR TITLE
Multi-bucket Deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ jobs:
           name: Push to S3
           command: |
               if [[ "$CIRCLE_PROJECT_USERNAME" == "opendatakit" ]]; then \
-                s3_website push --config-dir='odk1-config'
+                s3_website push --config-dir=odk1-config
               fi
   deploy-odk2:
     working_directory: ~/work
@@ -177,7 +177,7 @@ jobs:
           name: Push to S3
           command: |
               if [[ "$CIRCLE_PROJECT_USERNAME" == "opendatakit" ]]; then \
-                s3_website push --config-dir='odk2-config'
+                s3_website push --config-dir=odk2-config
               fi
   deploy-shared:
     working_directory: ~/work
@@ -197,7 +197,7 @@ jobs:
           name: Push to S3
           command: |
               if [[ "$CIRCLE_PROJECT_USERNAME" == "opendatakit" ]]; then \
-                s3_website push --config-dir='shared-config'
+                s3_website push --config-dir=shared-config
               fi
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
           root: ~/work
           paths:
             - odk1-build/*
-            - s3_website.yml
+            - odk1-config/*
   build-pdf-odk1:
     working_directory: ~/work
     docker:
@@ -117,6 +117,7 @@ jobs:
           root: ~/work
           paths:
             - odk2-build/*
+            - odk2-config/*
   build-pdf-odk2:
     working_directory: ~/work
     docker:
@@ -138,16 +139,13 @@ jobs:
           root: ~/work
           paths:
             - odk2-build/*
-  deploy:
+  deploy-odk1:
     working_directory: ~/work
     docker:
       - image: circleci/ruby:latest
     steps:
       - attach_workspace:
           at: ~/work
-      - run: |
-          cp -r odk1-build/ build
-          cp -r odk2-build/ build/odk2
       - run:
           name: Install deploy requirements
           command: |
@@ -159,8 +157,49 @@ jobs:
           name: Push to S3
           command: |
               if [[ "$CIRCLE_PROJECT_USERNAME" == "opendatakit" ]]; then \
-                s3_website push
+                s3_website push --config-dir='odk1-config'
               fi
+  deploy-odk2:
+    working_directory: ~/work
+    docker:
+      - image: circleci/ruby:latest
+    steps:
+      - attach_workspace:
+          at: ~/work
+      - run:
+          name: Install deploy requirements
+          command: |
+              if [[ "$CIRCLE_PROJECT_USERNAME" == "opendatakit" ]]; then \
+                sudo apt-get install -y openjdk-8-jre-headless
+                gem install s3_website && s3_website install
+              fi
+      - run:
+          name: Push to S3
+          command: |
+              if [[ "$CIRCLE_PROJECT_USERNAME" == "opendatakit" ]]; then \
+                s3_website push --config-dir='odk2-config'
+              fi
+  deploy-shared:
+    working_directory: ~/work
+    docker:
+      - image: circleci/ruby:latest
+    steps:
+      - attach_workspace:
+          at: ~/work
+      - run:
+          name: Install deploy requirements
+          command: |
+              if [[ "$CIRCLE_PROJECT_USERNAME" == "opendatakit" ]]; then \
+                sudo apt-get install -y openjdk-8-jre-headless
+                gem install s3_website && s3_website install
+              fi
+      - run:
+          name: Push to S3
+          command: |
+              if [[ "$CIRCLE_PROJECT_USERNAME" == "opendatakit" ]]; then \
+                s3_website push --config-dir='shared-config'
+              fi
+
 workflows:
   version: 2
   build_deploy:
@@ -173,10 +212,15 @@ workflows:
       - build-pdf-odk2:
           requires:
             - build-odk2
-      - deploy:
+      - deploy-odk1:
           requires:
             - build-odk1
             - build-pdf-odk1
+          filters:
+            branches:
+              only: master
+      - deploy-odk2:
+          requires:
             - build-odk2
             - build-pdf-odk2
           filters:

--- a/odk1-config/s3_website.yml
+++ b/odk1-config/s3_website.yml
@@ -1,7 +1,7 @@
-s3_bucket: docs.opendatakit.org
+s3_bucket: odk1-docs-web
 s3_endpoint: us-west-2
 
-site: build
+site: ../odk1-build
 
 error_document: index.html
 
@@ -12,7 +12,6 @@ exclude_from_upload:
   - .buildinfo
   - .doctrees
   - .DS_Store
-  - objects.inv
   - spelling
   - latex
 

--- a/odk2-config/s3_website.yml
+++ b/odk2-config/s3_website.yml
@@ -1,0 +1,29 @@
+s3_bucket: odk2-docs-web
+s3_endpoint: us-west-2
+s3_key_prefix: odk2
+
+site: ../odk2-build
+
+error_document: index.html
+
+max_age: 300
+gzip: true
+
+exclude_from_upload:
+  - .buildinfo
+  - .doctrees
+  - .DS_Store
+  - spelling
+  - latex
+
+cloudfront_distribution_id: E1IDKKW65Q2HVZ
+
+cloudfront_distribution_config:
+  default_cache_behavior:
+    min_ttl: <%= 60 * 60 * 24 %>
+  aliases:
+    quantity: 1
+    items:
+      - docs.opendatakit.org
+
+cloudfront_wildcard_invalidation: true

--- a/shared-config/s3_website.yml
+++ b/shared-config/s3_website.yml
@@ -1,0 +1,29 @@
+s3_bucket: shared-docs-web
+s3_endpoint: us-west-2
+s3_key_prefix: shared
+
+site: ../shared-build
+
+error_document: index.html
+
+max_age: 300
+gzip: true
+
+exclude_from_upload:
+  - .buildinfo
+  - .doctrees
+  - .DS_Store
+  - spelling
+  - latex
+
+cloudfront_distribution_id: E1IDKKW65Q2HVZ
+
+cloudfront_distribution_config:
+  default_cache_behavior:
+    min_ttl: <%= 60 * 60 * 24 %>
+  aliases:
+    quantity: 1
+    items:
+      - docs.opendatakit.org
+
+cloudfront_wildcard_invalidation: true

--- a/shared-config/s3_website.yml
+++ b/shared-config/s3_website.yml
@@ -14,7 +14,6 @@ exclude_from_upload:
   - .doctrees
   - .DS_Store
   - spelling
-  - latex
 
 cloudfront_distribution_id: E1IDKKW65Q2HVZ
 


### PR DESCRIPTION
## What is included in this PR?

1. This PR adds `s3_website.yml` configuration for odk2-docs and shared-docs. Given that there will be 3 `s3_website.yml`, the 3 files are placed in their respective `*-config` directory. 

2. `objects.inv` is removed from `s3_website.yml` exclude list. This file is essential for [intersphinx](http://www.sphinx-doc.org/en/master/ext/intersphinx.html).

3. CircleCI `deploy` job is split into 3: `deploy-odk1`, `deploy-odk2`, and `deploy-shared` to support separate deployment for these 3 Sphinx sites that will act as 1 website using AWS CloudFront. At this point there is no need to deploy shared, however by setting this up it will allow the cross referenced files to be added back into our documentation instead of having duplicate files copied into each deployment. 