### PR TITLE
Add intersphinx mapping

### DIFF
--- a/odk1-src/conf.py
+++ b/odk1-src/conf.py
@@ -257,7 +257,7 @@ Download this documentation as a PDF.
 """
 odk_pdf = """
 
-../_downloads/ODK1-Documentation.pdf
+_downloads/ODK1-Documentation.pdf
 
 """
 prob_in_doc = """

--- a/odk1-src/conf.py
+++ b/odk1-src/conf.py
@@ -225,7 +225,11 @@ epub_exclude_files = ['search.html']
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/', None),
+    'shared': ('https://docs.opendatakit.org/shared', None),
+    'odk2': ('https://docs.opendatakit.org/odk2', None)
+}
 
 # Add custom CSS
 

--- a/odk2-src/conf.py
+++ b/odk2-src/conf.py
@@ -257,7 +257,7 @@ Download this documentation as a PDF.
 """
 odk_pdf = """
 
-../_downloads/ODK2-Documentation.pdf
+_downloads/ODK2-Documentation.pdf
 
 """
 prob_in_doc = """

--- a/odk2-src/conf.py
+++ b/odk2-src/conf.py
@@ -225,7 +225,11 @@ epub_exclude_files = ['search.html']
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/', None),
+    'shared': ('https://docs.opendatakit.org/shared', None),
+    'odk1': ('https://docs.opendatakit.org/', None)
+}
 
 # Add custom CSS
 

--- a/shared-src/_templates/footer.html
+++ b/shared-src/_templates/footer.html
@@ -11,10 +11,10 @@
   {% endif %}
 
   <hr/>
-  <p class="footerText"> <a href="{{ odk_pdf }}" download> {{ download_pdf }} </a></p>
+  <p class="footerText"> <a href="{{ pathto(odk_pdf, 1) }}" download> {{ download_pdf }} </a></p>
   <p class="footerText"> {{ faq_help }} <a href="{{ forum_here }}"> {{ forum }} </a> </p>
   <p class="footerText"> {{ prob_in_doc }} <a href="{{ file_issue_here }}"> {{ file_issue }} </a> </p>
-  <p class="footerText"> {{ contri_start }} <a href="{{ repo_here }}"> {{ fork_repo }} </a> {{ join }} <a href="{{ contri_guide }}"> {{ contri }} </a></p>
+  <p class="footerText"> {{ contri_start }} <a href="{{ repo_here }}"> {{ fork_repo }} </a> {{ join }} <a href="{{ pathto('contributing') }}"> {{ contri }} </a></p>
   
   <div role="contentinfo">
     <p>


### PR DESCRIPTION
## What is included in this PR?

1. Add intersphinx mappings to `odk1-docs` and `odk2-docs`. This will enable cross linking between documentations.
2. Use `pathto` to generate proper relative links for PDF download and Contributor's guide

**note**
In the build log, there will be warnings about missing `objects.inv` for odk1-docs and shared-docs. This is expected, as odk1-docs is still served by the old S3 bucket (prior to the conversion to multi-bucket setup) and shared-docs is empty now.
