### PR TITLE
Add back references across sites

### DIFF
--- a/odk2-src/aggregate-tables-extension.rst
+++ b/odk2-src/aggregate-tables-extension.rst
@@ -12,7 +12,7 @@ The `ODK 2.0 REST Protocol <https://github.com/opendatakit/opendatakit/wiki/ODK-
 Server Setup
 -------------------
 
-First you’ll have to install ODK Aggregate v1.4.15 to a server (see the ODK 1.x Aggregate Installation instructions).
+First you’ll have to install ODK Aggregate v1.4.15 to a server (see :doc:`aggregate-install`).
 
   #. Install ODK Aggregate v1.4.15 to a server.
   #. Log onto your ODK Aggregate v1.4.15 instance.

--- a/odk2-src/getting-started-2.rst
+++ b/odk2-src/getting-started-2.rst
@@ -202,9 +202,9 @@ The starting point for this is to have a fully configured application on your de
 Setting up the ODK Aggregate server
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Follow the instructions to install Aggregate from the ODK 1.x documentation. You must install the **ODK Aggregate v1.4.15** release. This is because we are transitioning away from Aggregate and towards :doc:`sync-endpoint`, but v1.4.15 will suit the purposes of this demo just fine.
+Follow the instructions for :doc:`aggregate-install`. You must install the **ODK Aggregate v1.4.15** release. This is because we are transitioning away from Aggregate and towards :doc:`sync-endpoint`, but v1.4.15 will suit the purposes of this demo just fine.
 
-Once you have installed ODK Aggregate, log in with your super-user account. That process is also covered in the Aggregate installation documentation.
+Once you have installed ODK Aggregate, log in with your super-user account. That process is also covered in :doc:`aggregate-install`.
 
 Once logged in, enable the :doc:`aggregate-tables-extension`. You should grant the user account on your device the :guilabel:`Administer Tables` permissions.
 

--- a/odk2-src/select-tool-suite.rst
+++ b/odk2-src/select-tool-suite.rst
@@ -73,6 +73,6 @@ The feature comparison table below illustrates the differences between the 1.0 a
 
 Trying Them Out
 -----------------------------
-  - Try the 1.x tools by visiting their getting started guide.
-  - Try the 2.x tools with the :doc:`getting-started-2`
+  - Try the 1.x tools with the :doc:`getting-started` guide.
+  - Try the 2.x tools with the :doc:`getting-started-2`.
 

--- a/shared-src/docs-style-guide.rst
+++ b/shared-src/docs-style-guide.rst
@@ -646,7 +646,7 @@ Section labels
 
 Section titles should almost always be preceded by labels.
 
-The only exception is very short subsections that repeat --- like the **Right** and **Wrong** titles in this document or the **XLSForm Rows** and **XForm XML** sections in the **Form Widgets** document.
+The only exception is very short subsections that repeat --- like the **Right** and **Wrong** titles in this document or the **XLSForm Rows** and **XForm XML** sections in the :doc:`form-widgets` document.
 
 In these cases, you may want to use the :rst:dir:`rubric` directive.
 

--- a/shared-src/docs-syntax-guide.rst
+++ b/shared-src/docs-syntax-guide.rst
@@ -139,22 +139,11 @@ These :rst:dir:`toctree` directives control the sidebar navigation menu. To add 
 Secondary tables of content
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Collections of documents are sometimes given their own table of content on an individual page. For example, the source for the document **Setting Up ODK Collect** looks like this:
-
-.. code-block:: rst
-
-  Setting Up ODK Collect
-  =========================
-
-  .. toctree::
-    :maxdepth: 2
-
-    collect-install
-    collect-connect
+Collections of documents are sometimes given their own table of content on an individual page. (See, for example, :doc:`collect-setup` and :doc:`collect-using`.)
 
 In these cases, the page containing the :rst:dir:`toctree` serves as a sort of intro page for the collection. That intro must, itself, be included in the :ref:`main-nav-menu`.
 
-The contents of a :rst:dir:`toctree` appear as section links in another :rst:dir:`toctree` it is included in. That is, if a :rst:dir:`toctree` in :file:`index.rst` lists ``collect-using``, and :file:`collect-using.rst` has a :rst:dir:`toctree`, then the contents of that second :rst:dir:`toctree` will appear in the :ref:`main-nav-menu`, as sub-items to ``collect-using``. (Indeed, this is precisely the case in the docs currently.)
+The contents of a :rst:dir:`toctree` appear as section links in another :rst:dir:`toctree` it is included in. That is, if a :rst:dir:`toctree` in :file:`index.rst` lists ``collect-using``, and :file:`collect-using.rst` has a :rst:dir:`toctree`, then the contents of that second :rst:dir:`toctree` will appear in the :ref:`main-nav-menu`, as sub-items to :doc:`collect-using`. (Indeed, this is precisely the case in the docs currently.)
 
 How ODK Docs uses main and secondary tables of content
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -934,7 +923,7 @@ We have added several custom text roles for writing about forms and the XForms a
 
 .. rst:role:: formstate
 
-  Specifies the state of the form in **ODK Collect**, which could be one of the following:
+  Specifies the state of the form in :doc:`collect-intro`, which could be one of the following:
 
   - Blank
   - Finalized

--- a/shared-src/faq.rst
+++ b/shared-src/faq.rst
@@ -33,7 +33,7 @@ Our `blog <https://opendatakit.org/blog/>`_ and `deployments page <https://opend
 How do I use ODK?
 ~~~~~~~~~~~~~~~~~~~~
 
-Please read the `Getting Started Guide <https://docs.opendatakit.org/getting-started>`_ section of our documentation to understand the initial instructions.
+Please read the :doc:`Getting Started Guide <getting-started>` section of our documentation to understand the initial instructions.
 
 Please read through the documentation on our `implementer instructions <https://opendatakit.org/use/>`_ and on the `developer wiki <https://github.com/opendatakit/opendatakit/wiki>`_.
 


### PR DESCRIPTION
addresses https://github.com/opendatakit/docs/pull/480#issuecomment-372384246

## What is included in this PR?
Adds back relative references that were removed when the source directory was split into ODK 1, ODK 2, and shared source.
