### PR TITLE
adds info on area calculation

### DIFF
--- a/odk1-src/_static/css/custom.css
+++ b/odk1-src/_static/css/custom.css
@@ -248,6 +248,15 @@ caption .headerlink::after {
     margin-bottom: 12px;
 }
 
+
+/* Unindent line blocks inside tables,
+   so that table cells can have line breaks */
+
+table.docutils div.line-block {
+    margin-left: 0;
+}
+
+
 /* Styling for rst roles and directives ends */
 
 /* Responsive css starts */

--- a/odk1-src/form-widgets.rst
+++ b/odk1-src/form-widgets.rst
@@ -1168,9 +1168,46 @@ Captures a user-entered series of location coordinates, forming a polygon.
   :header: type, name, label
 
   geoshape, shape_example, Select an area
-  
 
+.. _geoshape-area:
+    
+Calculating the area of a geoshape
+"""""""""""""""""""""""""""""""""""
+
+type
+  :tc:`calculate`
+calculation
+  :tc:`area(${geoshape})`
   
+The :tc:`area()` function calculates the land area,
+in square meters,
+of a polygon defined in a :ref:`geoshape-widget`.
+The value will be included in your completed survey data,
+and can also be used in later widgets in the form.
+
+.. image:: /img/form-widgets/area-calc-0.* 
+  :alt: The geoshape widget. The question label is "Record a geoshape". The button label is "Start GeoShape".
+
+.. image:: /img/form-widgets/area-calc-1.* 
+  :alt: A map with four pins defining an area around a city block.
+    
+.. image:: /img/form-widgets/area-calc-2.* 
+  :alt: The geoshape widget with a series of lat/long coordinates.
+  
+.. image:: /img/form-widgets/area-calc-3.* 
+  :alt: A note widget. "The area of the recorded geoshape is 19322 square meters."
+  
+.. rubric:: XLSForm
+
+.. csv-table::
+  :header: type, name, label, calculation
+  
+  geoshape, shape, Record a Geoshape, 
+  calculate, shape_area, ,area(${shape})
+  calculate, rounded_shape_area, ,"round(${shape_area}, 2)"
+  note, shape_area_note, "| The area of the recorded geoshape is:
+  | ${rounded_shape_area} m²",  
+
 .. _bearing-widget:
 
 Bearing widget

--- a/odk1-src/img/form-widgets/area-calc-0.png
+++ b/odk1-src/img/form-widgets/area-calc-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7b1df32f4d055d79c11fc116c3429588178d754f08de55604080318ba2d5682
+size 67084

--- a/odk1-src/img/form-widgets/area-calc-1.png
+++ b/odk1-src/img/form-widgets/area-calc-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3edf4c115eb0b673da548c08fe1523f037fe3ef5842d3d6d98df7202237d3f2
+size 234367

--- a/odk1-src/img/form-widgets/area-calc-2.png
+++ b/odk1-src/img/form-widgets/area-calc-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0cb3f95c44eb8c8a69f2f61448cbb5e2cac30ea64ebc921558d0bbc25bc43cba
+size 84998

--- a/odk1-src/img/form-widgets/area-calc-3.png
+++ b/odk1-src/img/form-widgets/area-calc-3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c2e97175756a6d53fc785fa1069d1b4a428912d38f3ab894a3978e233f56982
+size 65111


### PR DESCRIPTION
closes #23 

## What is included in this PR?

Info on using `area()` to get area of a geoshape.

Also:
some CSS to make it so you can use line breaks in a csv-table

## What problems did you encounter?

Brought up on Slack ---
I had some issues with geotrace map on a device with no cell connection.

Using Google Maps, the widget opened to a white screen with no map displayed.

Using Open Street Maps, it kept resetting to 0,0.

I wanted to test if `area` worked on a geotrace-defined polygon (I assume so), 
but I was unable to test geotrace because of this issue.

I just included the info in geoshape. IT might be good to add a note to geotrace if it works there as well.
