### PR TITLE
remove shared and py from intersphinx

### DIFF
--- a/odk1-src/conf.py
+++ b/odk1-src/conf.py
@@ -226,8 +226,7 @@ epub_exclude_files = ['search.html']
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/', None),
-    'shared': ('https://docs.opendatakit.org/shared', None),
+    # 'py': ('https://docs.python.org/', None),
     'odk2': ('https://docs.opendatakit.org/odk2', None)
 }
 

--- a/odk2-src/conf.py
+++ b/odk2-src/conf.py
@@ -226,8 +226,7 @@ epub_exclude_files = ['search.html']
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/', None),
-    'shared': ('https://docs.opendatakit.org/shared', None),
+    # 'py': ('https://docs.python.org/', None),
     'odk1': ('https://docs.opendatakit.org/', None)
 }
 


### PR DESCRIPTION
`shared` is not a sphinx site --- it gets pulled into odk1 and odk2 at build time
so we shouldn't include it as an intersphinx mapping

Additionally, I commented out the python mapping,
as I don't see (currently) as reason for us to be referring to it.