### PR TITLE
Update xlsform

### DIFF
--- a/odk1-src/form-design-intro.rst
+++ b/odk1-src/form-design-intro.rst
@@ -22,9 +22,8 @@ JavaRosa-compliant build tools
 
 Most ODK users design their forms in Excel, following the `XLSForm <http://xlsform.org/>`_ specification. To convert XLSForms to XForms, you can use:
 
-- `ODK's online XLSForm converter <http://opendatakit.org/xiframe/>`_
-- `XLSForm Offline for Mac or Windows <https://gumroad.com/l/xlsform-offline>`_
-- `XLSForm for Windows <https://opendatakit.org/downloads/download-info/xlsform-for-windows/>`_
+- `XLSForm Online <https://opendatakit.org/xiframe/>`_
+- `XLSForm Offline <https://github.com/opendatakit/xlsform-offline/releases>`_
 - :doc:`pyxform`, a Python XLSForm converter with a command-line tool
 
 .. tip::

--- a/odk1-src/xlsform.rst
+++ b/odk1-src/xlsform.rst
@@ -8,13 +8,13 @@ XLSForm
 
 .. _xlsform-introduction:
 
-:dfn:`XLSForm` is a tool to simplify the creation of forms. Forms designed with Excel can be converted to *XForms* that can be used with ODK tools. It is available for use as `XLSForm Online <https://opendatakit.org/xiframe/>`_ and `XLSForm Offline <https://github.com/opendatakit/xlsform-offline/releases>`_
+:dfn:`XLSForm` is a tool to simplify the creation of forms. Forms designed with Excel can be converted to *XForms* that can be used with ODK tools. It is available for use as `XLSForm Online <https://opendatakit.org/xiframe/>`_ and `XLSForm Offline <https://github.com/opendatakit/xlsform-offline/releases>`_.
 
 
 Using the Application
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-- To design your form, you can refer to the `XLSForm form design documentation <http://xlsform.org/>`_ and check out the `sample Excel file <https://opendatakit.org/wp-content/uploads/2013/06/sample_xlsform.xls>`_.
+- To design your form, you can refer to the `XLSForm form design documentation <http://xlsform.org/>`_.
 - Once your XLSForm is ready, you convert it with `XLSForm Online <https://opendatakit.org/xiframe/>`_ and `XLSForm Offline <https://github.com/opendatakit/xlsform-offline/releases>`_.
 
 
@@ -26,6 +26,4 @@ Other XLSForm converters
 
 .. note::
   
-  - `Enketo <https://enketo.org/>`_ previews generated from this converter will not include media.
   - Forms do not have to be uploaded to :ref:`Aggregate <aggregate-introduction>` before they are used. They can be manually added to :ref:`Collect <collect-introduction>`. Simply place them in the :file:`/odk/forms` folder on your Android device’s SD card.
-  - For a simpler, more user friendly form designer, try `Build <https://opendatakit.org/use/build/>`_. We also have `sample forms <https://github.com/opendatakit/sample-forms/>`_ (Examples forms are not available for all the features) and `form design documentation <https://opendatakit.org/help/form-design/>`_. And in particular, `design guidelines <https://opendatakit.org/help/form-design/guidelines/>`_ if you wish to design forms manually.

--- a/odk1-src/xlsform.rst
+++ b/odk1-src/xlsform.rst
@@ -8,14 +8,15 @@ XLSForm
 
 .. _xlsform-introduction:
 
-:dfn:`XLSForm` is a tool to simplify the creation of forms. Forms designed with Excel can be converted to *XForms* that can be used with ODK tools.
+:dfn:`XLSForm` is a tool to simplify the creation of forms. Forms designed with Excel can be converted to *XForms* that can be used with ODK tools. It is available for use as `XLSForm Online <https://opendatakit.org/xiframe/>`_ and `XLSForm Offline <https://github.com/opendatakit/xlsform-offline/releases>`_
 
 
 Using the Application
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 - To design your form, you can refer to the `XLSForm form design documentation <http://xlsform.org/>`_ and check out the `sample Excel file <https://opendatakit.org/wp-content/uploads/2013/06/sample_xlsform.xls>`_.
-- Once your xls form is ready, you can submit it `for conversion here <http://opendatakit.org/xiframe/>`_.
+- Once your XLSForm is ready, you convert it with `XLSForm Online <https://opendatakit.org/xiframe/>`_ and `XLSForm Offline <https://github.com/opendatakit/xlsform-offline/releases>`_.
+
 
 Other XLSForm converters
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/odk1-src/xlsform.rst
+++ b/odk1-src/xlsform.rst
@@ -21,9 +21,10 @@ Other XLSForm converters
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - :ref:`pyxform <running-pyxform>` is a Python library. It works offline and can be used on the command line to convert forms.
+- `Ona <https://ona.io/home/>`_, `Kobo <http://www.kobotoolbox.org/>`_, and `Enketo <https://enketo.org/>`_ also offer XLSForm support.
 
 .. note::
   
   - `Enketo <https://enketo.org/>`_ previews generated from this converter will not include media.
   - Forms do not have to be uploaded to :ref:`Aggregate <aggregate-introduction>` before they are used. They can be manually added to :ref:`Collect <collect-introduction>`. Simply place them in the :file:`/odk/forms` folder on your Android device’s SD card.
-  - For a simpler, more user friendly form designer, try `Build <https://opendatakit.org/use/build/>`_. For more powerful form designers, try `Ona <https://ona.io/home/>`_, `Kobo <http://www.kobotoolbox.org/>`_, or `Enketo <https://enketo.org/>`_. We also have `sample forms <https://github.com/opendatakit/sample-forms/>`_ (Examples forms are not available for all the features) and `form design documentation <https://opendatakit.org/help/form-design/>`_. And in particular, `design guidelines <https://opendatakit.org/help/form-design/guidelines/>`_ if you wish to design forms manually.
+  - For a simpler, more user friendly form designer, try `Build <https://opendatakit.org/use/build/>`_. We also have `sample forms <https://github.com/opendatakit/sample-forms/>`_ (Examples forms are not available for all the features) and `form design documentation <https://opendatakit.org/help/form-design/>`_. And in particular, `design guidelines <https://opendatakit.org/help/form-design/guidelines/>`_ if you wish to design forms manually.

--- a/odk1-src/xlsform.rst
+++ b/odk1-src/xlsform.rst
@@ -20,15 +20,10 @@ Using the Application
 Other XLSForm converters
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- For Windows users, a standalone (non-web-based) version of this tool (without the error report) is also available on our `downloads page here <https://opendatakit.org/downloads/download-info/xlsform-for-windows/>`_. If you use that tool, you should also download ODK Validate (`from here <https://opendatakit.org/downloads/download-info/odk-validate-2/>`_) and run the generated form through that tool to generate an error report.
-- Nafundi's `XLSForm Offline <https://gumroad.com/l/xlsform-offline#/>`_ is an app for Windows and Mac that can convert and validate forms. It is always available, very fast, and easy to use.
 - :ref:`pyxform <running-pyxform>` is a Python library. It works offline and can be used on the command line to convert forms.
-- XLSForm is also available through `Ona <https://ona.io/home/>`_.io which requires internet connection and also makes it easy to share converted forms and collected data.
 
 .. note::
   
   - `Enketo <https://enketo.org/>`_ previews generated from this converter will not include media.
   - Forms do not have to be uploaded to :ref:`Aggregate <aggregate-introduction>` before they are used. They can be manually added to :ref:`Collect <collect-introduction>`. Simply place them in the :file:`/odk/forms` folder on your Android device’s SD card.
-  - For a simpler, more user friendly form designer, try `Build <https://opendatakit.org/use/build/>`_. For more powerful form designers, try `Kobo <http://www.kobotoolbox.org/>`_ or `enketo <https://enketo.org/>`_ or `PurcForms <https://code.google.com/archive/p/purcforms/>`_. We also have `sample forms <https://github.com/opendatakit/sample-forms/>`_ (Examples forms are not available for all the features) and `form design documentation <https://opendatakit.org/help/form-design/>`_. And in particular, `design guidelines <https://opendatakit.org/help/form-design/guidelines/>`_ if you wish to design forms manually.
-
-
+  - For a simpler, more user friendly form designer, try `Build <https://opendatakit.org/use/build/>`_. For more powerful form designers, try `Ona <https://ona.io/home/>`_, `Kobo <http://www.kobotoolbox.org/>`_, or `Enketo <https://enketo.org/>`_. We also have `sample forms <https://github.com/opendatakit/sample-forms/>`_ (Examples forms are not available for all the features) and `form design documentation <https://opendatakit.org/help/form-design/>`_. And in particular, `design guidelines <https://opendatakit.org/help/form-design/guidelines/>`_ if you wish to design forms manually.

--- a/odk1-src/xlsform.rst
+++ b/odk1-src/xlsform.rst
@@ -8,12 +8,7 @@ XLSForm
 
 .. _xlsform-introduction:
 
-:dfn:`XLSForm` (formerly XLS2Xform) is a tool to simplify the creation of forms. Forms designed with Excel can be converted to *XForms* that can be used with ODK tools.
-
-.. note::
-  
-  - When this tool was renamed to XLSForm there were many changes to the syntax. The new version is mostly backwards compatible with the old syntax.
-  - XLSForm works with ODK Collect version *1.1.7* or later.
+:dfn:`XLSForm` is a tool to simplify the creation of forms. Forms designed with Excel can be converted to *XForms* that can be used with ODK tools.
 
 
 Using the Application


### PR DESCRIPTION
Closes #644 

#### What is included in this PR?
Removal of tools that are old or unsupported
Addition of tools that are new and supported
Removal of links that are either broken or likely to break in the next few days

<!-- Answer any that apply and delete the others. -->
#### What new issues will need to be opened because of this PR?
I don't love that we have to link to xlsform.org for how to design forms given that we are in a docs site. It would be nice to have a high-level how to design forms link in the docs.

#### What is left to be done in the addressed issue?
We will eventually have to update the https://opendatakit.org/xiframe link when the new site launches. We might have to also update the link to https://github.com/opendatakit/xlsform-offline/releases