### PR TITLE
Redirect form-interaction to form-logic

### DIFF
--- a/odk1-config/s3_website.yml
+++ b/odk1-config/s3_website.yml
@@ -38,3 +38,4 @@ redirects:
   briefcase-forms/index.html: briefcase-using
   briefcase-vs-aggregate/index.html: briefcase-and-aggregate
   form-widgets/index.html: form-question-types
+  form-interaction/index.html: form-logic


### PR DESCRIPTION
Addresses #630

#### What is included in this PR?
Since we removed form-interaction, we should redirect it to form-logic (which is some fantastic content, BTW). I think this is how we do redirects now.

#### What is left to be done in the addressed issue?
I think @adammichaelwood has a magical script that was supposed to prevent this mistake from happening. Maybe. It'd be good to know where the knowledge gap is.