### PR TITLE
Form functions

### DIFF
--- a/odk1-src/_static/css/custom.css
+++ b/odk1-src/_static/css/custom.css
@@ -37,14 +37,31 @@ table, .th, .tc {
 /* formstate role PR #111 */
 
 .formstate {
-    font-style: italics;
+    font-style: italic;
 }
 
 /* gesture role PR #111 */
 
 .gesture {
-    font-style: italics;
+    font-style: italic;
 }
+
+/* Style function signature more sensibly, and
+/* add arg role, PR 660 (function reference) */
+
+.function dt {
+    font-family: Consolas,"Andale Mono WT","Andale Mono","Lucida Console","Lucida Sans Typewriter","DejaVu Sans Mono","Bitstream Vera Sans Mono","Liberation Mono","Nimbus Mono L",Monaco,"Courier New",Courier,monospace;
+}
+
+.arg {
+    font-family: Consolas,"Andale Mono WT","Andale Mono","Lucida Console","Lucida Sans Typewriter","DejaVu Sans Mono","Bitstream Vera Sans Mono","Liberation Mono","Nimbus Mono L",Monaco,"Courier New",Courier,monospace;
+    font-style: italic;
+    font-weight: bold;
+    color: #2980B9;
+    font-size: 90%;
+    
+}
+
 
 /* caption styling PR #90 */
 

--- a/odk1-src/conf.py
+++ b/odk1-src/conf.py
@@ -78,7 +78,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'incl']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'incl', 'incl/form-examples']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'default'
@@ -104,6 +104,11 @@ DirectoryHTMLBuilder.supported_image_types = [
     'image/png',
     'image/jpeg'
 ]
+
+# Set primary domain to JavaScript
+# which is syntactically compatible with XPath functions.
+
+primary_domain = 'js'
 
 # -- Options for HTML output ----------------------------------------------
 
@@ -250,6 +255,9 @@ rst_prolog="""
     
 .. role:: gesture
     :class: gesture
+
+.. role:: arg
+    :class: arg
 """
 
 # At bottom of every document

--- a/odk1-src/form-functions.rst
+++ b/odk1-src/form-functions.rst
@@ -1,0 +1,674 @@
+.. spelling::
+
+  Anaranjado
+  Azul
+  Colores
+  Español
+  Púrpura
+  Qué
+  Rojo
+  Seleccione
+  arctan
+  arg
+  bday
+  bp
+  br
+  chkn
+  colores
+  fsh
+  gustan
+  jr
+  nodeset
+  prefs
+  seleccionados
+  te
+  tres
+  π
+  
+  
+	
+******************************
+Form Functions and Operators
+******************************
+
+:ref:`expressions` in :ref:`calculations`, :ref:`constraints <constraints>`, and :ref:`relevants <relevants>`
+can contain `XPath functions`_ and operators.
+
+.. _XPath functions: https://opendatakit.github.io/xforms-spec/#xpath-functions
+
+.. contents::
+  :local:   
+
+.. _functions:
+  
+Functions
+===========
+    
+.. _control-flow-functions:
+
+Control flow
+--------------
+
+.. function:: if(expression, then, else)
+
+  Returns :arg:`then` if :arg:`expression` evaluates to ``True``. 
+  Otherwise, returns :arg:`else`.
+
+  
+.. function:: not(arg)
+
+  Returns the opposite of :func:`boolean(arg) <boolean>`.
+
+  
+.. function:: coalesce(arg, arg) 	
+
+  Returns first non-empty value of the two :arg:`arg`\ s.
+  Returns an empty string if both are empty or non-existent.
+
+  
+.. function:: true()
+
+  Evaluates to ``True``.
+
+.. function:: false()
+
+  Evaluates to ``False``.
+  
+.. function:: boolean(arg) 
+
+  Returns ``True`` if :arg:`arg` is:
+  
+  - a number other than zero
+  - a non-empty string
+  - a non-empty collection
+  - a comparison or expressions that evaluates to ``True``.
+   
+  Returns ``False`` if :arg:`arg` is:
+  
+  - the number 0
+  - an empty string
+  - an empty collection
+  - a comparison or expression that evaluates to ``False``.
+
+.. _response-access-functions:
+  
+Accessing response values
+--------------------------
+
+.. note::
+
+  The response from most question types
+  can be accessed using :ref:`variables <variables>`.
+  Functions are needed for accessing responses to 
+  :ref:`multi select questions <select-functions>` and
+  questions inside :ref:`repeat groups <repeat-functions>`.
+
+.. _select-functions:
+  
+Select questions
+~~~~~~~~~~~~~~~~~~~
+
+.. function:: selected(select_question, choice_name)
+
+  Returns ``True`` if :arg:`choice_name` 
+  was selected in :arg:`select_question`,
+  otherwise returns ``False``.
+  
+  .. include:: incl/form-examples/constraint-on-selected.rst
+  
+.. function:: selected-at(multi_select_question, n)
+
+  Returns the :th:`name` of the :arg:`n`\ :sup:`th` selected choice of the :arg:`multi_select_question`. (Selected choices are zero-indexed.)
+  
+  .. note::
+  
+    This function returns the :th:`name`, not the :th:`label`,
+    of the selected choice.
+    To get the label in the current language,
+    use :func:`jr:choice-name`.
+  
+  Returns an empty string if the index does not exist.
+  
+  .. image:: /img/form-functions/selected-at-0.* 
+    :alt: A multi-select widget in Collect. The label is "What colors do you like?" Several color names are presented as options. Red, Green, and Purple are selected.
+  
+  .. image:: /img/form-functions/selected-at-1.* 
+    :alt: A note widget in Collect. The label is "Selected Colors". The hint text is "red, green, purple".
+  
+  .. rubric:: XLSForm
+  
+  .. csv-table:: survey
+    :header: type, name, label, hint, calculation
+  
+    select_multiple colors, color_prefs, What colors do you like?, Select three.
+    calculate, color_0, , ,"selected-at(${color_prefs}, 0)"
+    calculate, color_1, , ,"selected-at(${color_prefs}, 1)"
+    calculate, color_2, , ,"selected-at(${color_prefs}, 2)"
+    note, color_note, Selected colors:, ${color_0} <br> ${color_1} <br> ${color_2}  
+
+  .. csv-table:: choices
+    :header: list_name, name, label
+    
+    colors, red, Red
+    colors, blue, Blue
+    colors, yellow, Yellow
+    colors, green, Green
+    colors, orange, Orange
+    colors, purple, Purple
+
+.. function:: count-selected(multi_select_question)
+
+  Returns the number of choices selected in ``multi_select_question``.
+  
+  .. image:: /img/form-functions/count-selected-constraint.* 
+    :alt: A multi-select widget in Collect. The label is "What colors do you like?" The hint text is "Select three." Four colors are selected. A message modal overlays the widget with the text "Select exactly three."
+  
+  .. rubric:: XLSForm
+  
+  .. csv-table:: survey
+    :header: type, name, label, hint, constraint, constraint_message
+    
+    select_multiple colors, color_prefs, What colors do you like?, Select three., count-selected(.)=3, Select exactly three.
+    
+  .. csv-table:: choices
+    :header: list_name, name, label
+    
+    colors, red, Red
+    colors, blue, Blue
+    colors, yellow, Yellow
+    colors, green, Green
+    colors, orange, Orange
+    colors, purple, Purple
+
+.. function:: jr:choice-name(choice_name, 'select_question')
+
+  Returns the label value, in the active language, associated with the :arg:`choice_name` in the list of choices for the :arg:`select_question`.
+  
+  .. note::
+  
+    You have to wrap the :arg:`select_question` reference in quotes.
+    
+    .. code-block:: none
+    
+      '${question_name}'
+  
+  .. image:: /img/form-functions/choice-name-multi-lang-english-0.* 
+    :alt: A multi-select widget in Collect. The label is "What colors do you like?" Several color names are presented as options. Red, Green, and Purple are selected.
+  
+  .. image:: /img/form-functions/choice-name-multi-lang-english-1.* 
+    :alt: A note widget in Collect. The label is "Selected colors". The hint text is "Red, Green, Purple."
+  
+  .. image:: /img/form-functions/choice-name-multi-lang-spanish-0.* 
+    :alt: A multi-select widget in Collect. The label is "¿Qué colores te gustan?" Several color names, in Spanish, are presented as options. Rojo, Verde, and Púrpura are selected.
+    
+  .. image:: /img/form-functions/choice-name-multi-lang-spanish-1.* 
+    :alt: A note widget in Collect. The label is "Colores seleccionados." The hint text is "Rojo, Verde, Púrpura".
+    
+  .. rubric:: XLSForm
+  
+  .. csv-table::  survey
+    :header: type, name, label::English, label::Español, hint::English, hint:Español, calculation
+    
+    select_multiple colors, color_prefs, What colors do you like?, ¿Qué colores te gustan?, Select three., Seleccione tres.
+    calculate, color_0, , , , ,"jr:choice-name( selected-at(${color_prefs}, 0), '${color_prefs}')"
+    calculate, color_1, , , , ,"jr:choice-name( selected-at(${color_prefs}, 2), '${color_prefs}')"
+    calculate, color_2, , , , ,"jr:choice-name( selected-at(${color_prefs}, 2), '${color_prefs}')"
+    note, color_note, Selected colors:, Colores seleccionados:, ${color_0} <br> ${color_1} <br> ${color_2}, ${color_0} <br> ${color_1} <br> ${color_2}
+    
+  .. csv-table:: choices
+    :header: list_name, name, label::English, label::Español
+    
+    colors, red, Red, Rojo
+    colors, blue, Blue, Azul
+    colors, yellow, Yellow, Amarillo
+    colors, green, Green, Verde
+    colors, orange, Orange, Anaranjado
+    colors, purple, Purple, Púrpura
+  
+.. _repeat-functions:
+    
+Repeat groups
+~~~~~~~~~~~~~~~~
+
+.. admonition:: Helpful terms
+
+  .. glossary::
+    :sorted:
+
+    nodeset
+
+      A collection of response values. 
+
+      Outside a :ref:`repeat group <repeats>`, 
+      :ref:`referring to a question by name <variables>`
+      will return a nodeset containing all the responses to that question.
+
+        
+.. function:: indexed-repeat(name, group, i [, sub_grp, sub_i [, sub_sub_grp, sub_sub_i ]])
+
+  Returns the response value of question :arg:`name`
+  from the repeat-group :arg:`group`,
+  in iteration :arg:`i`.
+  
+  Nested repeat groups can be accessed 
+  using the :arg:`sub` and :arg:`sub_sub` parameters.
+
+  .. seealso:: :ref:`referencing-answers-in-repeats`
+
+  .. include:: incl/form-examples/parallel-repeat-groups.rst
+
+.. function:: count(nodeset)
+
+  Returns the number of items in :arg:`nodeset`. This can be used to count the number of repetitions in a :ref:`repeat group <repeats>`.
+
+  .. include:: incl/form-examples/parallel-repeat-groups.rst
+  
+.. function:: count-non-empty(nodeset)
+
+  Returns the number of non-empty members of :arg:`nodeset`.
+
+.. function:: sum(nodeset)
+
+  Returns the sum of the members of :arg:`nodeset`.
+  
+  Can be used to :ref:`tally responses to a repeated select question <counting-answers>`.
+  
+  .. include::  incl/form-examples/sum-to-count-responses.rst
+
+.. function:: max(nodeset)
+
+  Returns the largest member of :arg:`nodeset`.
+  
+  .. rubric:: XLSForm
+  
+  .. csv-table:: survey
+    :header: type, name, label, calculation
+    
+    begin_repeat, child_questions, Questions about child
+    text, child_name, Child's name
+    integer, child_age, Child's age
+    end_repeat
+    calculate, age_of_oldest_child, , max(${child_age})
+
+.. function:: min(nodeset)
+
+  Returns the smallest member of :arg:`nodeset`.
+  
+  .. rubric:: XLSForm
+  
+  .. csv-table:: survey
+    :header: type, name, label, calculation
+    
+    begin_repeat, child_questions, Questions about child
+    text, child_name, Child's name
+    integer, child_age, Child's age
+    end_repeat
+    calculate, age_of_youngest_child, , min(${child_age}) 
+  
+.. _string-functions:
+  
+Strings
+--------
+
+.. _string-comparison-functions:
+
+Searching and matching strings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+.. function:: regex(string, expression)
+
+    Returns ``True`` if :arg:`string` is an *exact and complete* match for :arg:`expression`.
+
+  .. seealso:: :doc:`form-regex`
+  
+  .. include:: incl/form-examples/regex-middle-initial.rst
+
+
+.. function:: contains(string, substring)
+
+  Returns ``True`` if the :arg:`string` contains the :arg:`substring`.
+
+.. function:: starts-with(string, substring)
+
+  Returns ``True`` if :arg:`string` begins with :arg:`substring`.
+
+.. function:: ends-with(string, substring)
+
+  Returns ``True`` if the :arg:`string` ends with :arg:`substring`.
+
+
+.. function:: substr(string, start[, end]) 	
+
+  Returns the substring of :arg:`string` beginning at the index :arg:`start` and extending to (but not including) index :arg:`end` (or to the termination of :arg:`string`, if :arg:`end` is not provided). Members of arg:`string` are zero-indexed.
+  
+.. function:: string-length(string)
+
+  Returns the number of characters in :arg:`string`.
+  
+.. _string-combination-functions:
+  
+Combining strings
+~~~~~~~~~~~~~~~~~~  
+
+.. function:: concat(arg [, arg [, arg [, arg [...]]]])
+
+  Concatenates one or more arguments into a single string. If any :arg:`arg` is a :term:`nodeset`, the values within the set are concatenated into a string.
+
+  
+.. function:: join(separator, nodeset)
+
+  Joins the members of :arg:`nodeset`, using the string :arg:`separator`.
+
+.. _string-conversion-functions:
+  
+Converting to and from strings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. function:: boolean-from-string(string)
+
+  Returns ``True`` if :arg:`string` is "true" or "1".
+  Otherwise, ``False``.
+
+
+.. function:: number(string)
+
+  Converts a :arg:`string` of digits into a number value.
+
+.. function:: string(arg)
+
+   Converts :arg:`arg` to a string.
+
+.. _math-functions:
+  
+Math and numbers
+------------------
+
+.. function:: round(number, places)
+
+  Rounds a decimal :arg:`number` to some number of decimal :arg:`places`.
+
+.. function:: int(arg) 	
+
+  Converts :arg:`arg` to an integer.
+
+
+.. function:: pow(number, power)
+
+  Raises a :arg:`number` to a :arg:`power`.
+
+.. function:: log(number)
+
+  Returns the natural log of :arg:`number`.
+
+.. function:: log10(number)
+
+  Returns the base-10 log of :arg:`number`.
+
+.. function:: abs(number)
+
+  Returns the absolute value of :arg:`number`.
+
+.. function:: sin(number)
+
+  Returns the sine of :arg:`number`.
+
+.. function:: cos(number)
+
+  Returns the cosine of :arg:`number`.
+  
+.. function:: tan(number)
+
+  Returns the tangent of :arg:`number`.
+
+.. function:: asin(number)
+
+  Returns the arc sine of :arg:`number`.
+  
+.. function:: acos(number)
+
+  Returns the arc cosine of :arg:`number`.
+
+.. function:: atan(number)
+
+  Returns the arctan of :arg:`number`.
+
+.. function:: atan2(y,x)
+
+  Returns the multi-valued inverse tangent of :arg:`y`, :arg:`x`.
+
+.. function:: sqrt(number) 
+
+  Returns the square root of :arg:`number`.
+
+.. function:: exp(x) 
+
+  Returns ``e^x``.
+
+.. function:: exp10(x)
+
+  Returns ``10^x``.
+
+.. function:: pi()
+
+  Returns an approximation of the mathematical constant π.
+
+.. _date-time-functions:
+    
+Date and time
+----------------
+
+.. function:: today()
+
+  Returns the current date without a time component.
+
+.. function:: now()
+
+  Returns the current datetime in the current time zone.
+
+.. _date-time-conversion-functions:
+  
+Converting dates and time
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  
+.. function:: decimal-date-time(dateTime)
+
+  Converts :arg:`dateTime` value to the number of days since January 1, 1970 UTC. This is the format used by Excel.
+  
+  This is the inverse of :func:`date`.
+
+.. function:: date(days)
+
+  Converts an integer representing a number of :arg:`days` from 01 January 1970 (the `Unix Epoch`_) to a standard date value.
+
+  .. _Unix Epoch: https://en.wikipedia.org/wiki/Unix_time
+    
+  This is the inverse of :func:`decimal-date-time`.
+
+    
+.. function:: decimal-time(time)
+
+  Converts :arg:`time` to a number representing a fractional day.
+  For example, noon is 0.5 and 6pm is 0.75.
+
+
+.. _date-time-formatting-functions:
+
+Formatting dates and times for display
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
+  
+  
+.. function:: format-date(date, format)
+
+  Returns :arg:`date` as a string formatted as defined by :arg`format`.
+  
+  The following identifiers are used in the :arg:`format` string:
+  
+  .. csv-table::
+  
+    %Y, 4-digit year
+    %y, 2-digit year
+    %m, 0-padded month
+    %n, numeric month
+    %b, "short text month (Jan, Feb, Mar...)" 
+    %d, 0-padded day of month
+    %e, day of month
+    %a, "short text day (Sun, Mon, Tue...)."
+
+  .. note:: 
+  
+    Month and day abbreviations are language and locale specific. If form locale can be determined, that locale will be used. Otherwise, the device locale will be used.
+  
+.. function:: format-date-time(dateTime, format)
+
+  Returns :arg:`dateTime` as a string formatted as defined by :arg:`format`.
+
+  The identifiers list in :func:`format-date` are available, 
+  plus the following:
+  
+  .. csv-table::
+  
+    %H, 0-padded hour (24-hr time)
+    %h, hour (24-hr time)
+    %M, 0-padded minute
+    %S, 0-padded second
+    %3, 0-padded millisecond ticks.
+
+.. _geography-functions:
+    
+Geography
+------------
+
+.. function:: area(nodeset | geoshape) 	
+
+  Returns the area, in square meters, 
+  of either a :arg:`nodeset` of geopoints or a :arg:`geoshape` value.
+  
+  It takes into account the circumference of the Earth around the Equator but does not take altitude into account.
+
+.. function:: distance(nodeset | geoshape | geotrace)
+
+  Returns the distance, in meters, of either:
+  
+  - a :arg:`nodeset` of geopoints
+  - the perimeter of a :arg:`geoshape`
+  - the length of a :arg:`geotrace` value
+  
+  It takes into account the circumference of the Earth around the Equator and does not take altitude into account.
+
+.. _utility-functions:
+
+Utility
+---------
+  
+.. function:: position(xpath)
+
+  Returns an integer equal to the 1-indexed position of the current node
+  within the node defined by :arg:`xpath`.
+  
+  Most often this is used in the form :tc:`position(..)`
+  to identify the current iteration index
+  within a repeat group.  
+  
+  .. include:: incl/form-examples/parallel-repeat-groups.rst
+
+.. function:: uuid([length]) 	
+
+  Without argument, returns a random `RFC 4122 version 4 compliant UUID`__. 
+  
+  __ https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)
+  
+  With an argument it returns a random GUID of specified :arg:`length`.  
+
+.. function:: once(expression)
+
+  Returns the value :arg:`expression` if the question's value is empty. Otherwise, returns the current value of the question.
+
+  This can be used to ensure that a random number is only generated once,
+  or to store the first value entered for a question
+  in a way that is retrievable even of the response is changed later.
+
+.. function:: random()
+
+  Returns a random number between 0.0 (inclusive) and 1.0 (exclusive).
+
+  
+.. function:: randomize(nodeset[, seed]) 	
+
+  Returns a shuffled :arg:`nodeset`.
+  
+  A shuffle with a numeric :arg:`seed` is deterministic and reproducible.
+  
+.. function:: checklist(min, max, response[, response[, response [, ... ]]])
+
+  Returns ``True`` if the number of :arg:`response`\ s that are exactly the string "yes" is between :arg:`min` and :arg:`max`, inclusive.  
+  
+  Set :arg:`min` or :arg:`max` to ``-1`` to make the argument not applicable.
+
+.. function:: weighted-checklist(min, max, reponse, weight[, response, weight[, response, weight[, response, weight[, ... ]]])
+
+  Returns ``True`` if 
+  the sum of the :arg:`weight`\ s 
+  of each :arg:`response` that is exactly the string "yes"
+  is between :arg:`min` and :arg:`max`, inclusive.
+  
+  Set :arg:`min` or :arg:`max` to ``-1`` to make the argument not 
+    
+
+.. _xform-operators:
+
+Operators
+==========
+
+.. _utility-operators:
+
+Utility operators
+-------------------
+
+.. csv-table::
+  :header: , Explanation, Example, Notes
+  
+  ., current question's value, . >= 18, Used in :ref:`constraints <constraints>`.
+  \.\., current question's parent group, position(..), Used with :func:`position` to get the iteration index.
+  
+.. _boolean-operators:
+  
+Boolean operators
+------------------
+
+.. csv-table::
+  :header: , Explanation, Example
+
+  and, ``True`` if the expressions before and after are ``True``, ${age} > -1 and ${age} < 120
+  or, ``True`` if either of the expressions before or after are ``True``, ${age} < 19 or ${age} > 64
+  
+.. _comparion-operators:
+  
+Comparison operators
+-----------------------
+  
+.. csv-table::
+  :header: , Explanation, Example, Notes
+  
+  =, equal to, ${enrolled} = 'yes', Can compare numbers or strings.
+  !=, not equal to, ${enrolled} != 'yes', Can compare numbers or strings.
+  >, greater than, ${age} > 17, 
+  >=, greater than or equal to, ${age} >= 18,
+  <, less than, ${age} < 65, 
+  <=, less than or equal to, ${age} <= 64,
+
+.. _math-operators:
+  
+Math operators
+---------------
+
+.. csv-table::
+  :header: , Explanation, Example, Notes
+  
+  \+, addition, ${salary_income} + ${self_employed_income}, Numbers only; does not concatenate strings.
+  \-, subtraction, ${income} - ${expenses},
+  \*, multiplication, ${bill} * 1.18,
+  div, division, ${percent_int} div 100, 
+  mod, `modulo`_ (division remainder), (. mod 2) = 0, 
+
+.. _modulo: https://en.wikipedia.org/wiki/Modulo_operation

--- a/odk1-src/form-functions.rst
+++ b/odk1-src/form-functions.rst
@@ -31,14 +31,75 @@
 Form Functions and Operators
 ******************************
 
-:ref:`expressions` in :ref:`calculations`, :ref:`constraints <constraints>`, and :ref:`relevants <relevants>`
-can contain `XPath functions`_ and operators.
+:ref:`expressions` in :ref:`calculations <calculations>`, :ref:`constraints <constraints>`, and :ref:`relevants <relevants>`
+can contain operators and functions.
 
-.. _XPath functions: https://opendatakit.github.io/xforms-spec/#xpath-functions
+.. seealso:: `XPath Functions <https://opendatakit.github.io/xforms-spec/#xpath-functions>`_
 
 .. contents::
   :local:   
 
+  
+.. _xform-operators:
+
+Operators
+==========
+
+.. _utility-operators:
+
+Utility operators
+-------------------
+
+.. csv-table::
+  :header: , Explanation, Example, Notes
+  
+  ., current question's value, . >= 18, Used in :ref:`constraints <constraints>`.
+  \.\., current question's parent group, position(..), Used with :func:`position` to get the iteration index.
+  
+.. _boolean-operators:
+  
+Boolean operators
+------------------
+
+.. csv-table::
+  :header: , Explanation, Example
+
+  and, ``True`` if the expressions before and after are ``True``, ${age} > -1 and ${age} < 120
+  or, ``True`` if either of the expressions before or after are ``True``, ${age} < 19 or ${age} > 64
+  
+.. _comparison-operators:
+  
+Comparison operators
+-----------------------
+  
+.. csv-table::
+  :header: , Explanation, Example, Notes
+  
+  =, equal to, ${enrolled} = 'yes', Can compare numbers or strings.
+  !=, not equal to, ${enrolled} != 'yes', Can compare numbers or strings.
+  >, greater than, ${age} > 17, 
+  >=, greater than or equal to, ${age} >= 18,
+  <, less than, ${age} < 65, 
+  <=, less than or equal to, ${age} <= 64,
+
+.. _math-operators:
+  
+Math operators
+---------------
+
+.. csv-table::
+  :header: , Explanation, Example, Notes
+  
+  \+, addition, ${salary_income} + ${self_employed_income}, Numbers only; does not concatenate strings.
+  \-, subtraction, ${income} - ${expenses},
+  \*, multiplication, ${bill} * 1.18,
+  div, division, ${percent_int} div 100, 
+  mod, `modulo`_ (division remainder), (${even_number} mod 2) = 0, 
+
+.. _modulo: https://en.wikipedia.org/wiki/Modulo_operation
+
+  
+  
 .. _functions:
   
 Functions
@@ -55,40 +116,27 @@ Control flow
   Otherwise, returns :arg:`else`.
 
   
-.. function:: not(arg)
-
-  Returns the opposite of :func:`boolean(arg) <boolean>`.
-
   
-.. function:: coalesce(arg, arg) 	
+.. function:: position(xpath)
 
-  Returns first non-empty value of the two :arg:`arg`\ s.
-  Returns an empty string if both are empty or non-existent.
-
+  Returns an integer equal to the 1-indexed position of the current node
+  within the node defined by :arg:`xpath`.
   
-.. function:: true()
-
-  Evaluates to ``True``.
-
-.. function:: false()
-
-  Evaluates to ``False``.
+  Most often this is used in the form :tc:`position(..)`
+  to identify the current iteration index
+  within a repeat group.  
   
-.. function:: boolean(arg) 
+  .. include:: incl/form-examples/parallel-repeat-groups.rst
 
-  Returns ``True`` if :arg:`arg` is:
-  
-  - a number other than zero
-  - a non-empty string
-  - a non-empty collection
-  - a comparison or expressions that evaluates to ``True``.
-   
-  Returns ``False`` if :arg:`arg` is:
-  
-  - the number 0
-  - an empty string
-  - an empty collection
-  - a comparison or expression that evaluates to ``False``.
+.. function:: once(expression)
+
+  Returns the value :arg:`expression` if the question's value is empty. Otherwise, returns the current value of the question.
+
+  This can be used to ensure that a random number is only generated once,
+  or to store the first value entered for a question
+  in a way that is retrievable even of the response is changed later.
+
+    
 
 .. _response-access-functions:
   
@@ -381,8 +429,13 @@ Converting to and from strings
 
 .. _math-functions:
   
-Math and numbers
-------------------
+Math 
+------
+
+.. _number-functions:
+
+Number handling
+~~~~~~~~~~~~~~~~~
 
 .. function:: round(number, places)
 
@@ -392,6 +445,12 @@ Math and numbers
 
   Converts :arg:`arg` to an integer.
 
+.. seealso:: :func:`count`, :func:`max`, :func:`min`, :func:`number`
+  
+.. _calculation-functions:
+  
+Calculation
+~~~~~~~~~~~~~
 
 .. function:: pow(number, power)
 
@@ -453,6 +512,7 @@ Math and numbers
 
   Returns an approximation of the mathematical constant π.
 
+  
 .. _date-time-functions:
     
 Date and time
@@ -560,33 +620,6 @@ Geography
 
 Utility
 ---------
-  
-.. function:: position(xpath)
-
-  Returns an integer equal to the 1-indexed position of the current node
-  within the node defined by :arg:`xpath`.
-  
-  Most often this is used in the form :tc:`position(..)`
-  to identify the current iteration index
-  within a repeat group.  
-  
-  .. include:: incl/form-examples/parallel-repeat-groups.rst
-
-.. function:: uuid([length]) 	
-
-  Without argument, returns a random `RFC 4122 version 4 compliant UUID`__. 
-  
-  __ https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)
-  
-  With an argument it returns a random GUID of specified :arg:`length`.  
-
-.. function:: once(expression)
-
-  Returns the value :arg:`expression` if the question's value is empty. Otherwise, returns the current value of the question.
-
-  This can be used to ensure that a random number is only generated once,
-  or to store the first value entered for a question
-  in a way that is retrievable even of the response is changed later.
 
 .. function:: random()
 
@@ -614,61 +647,48 @@ Utility
   
   Set :arg:`min` or :arg:`max` to ``-1`` to make the argument not 
     
+.. function:: uuid([length]) 	
 
-.. _xform-operators:
-
-Operators
-==========
-
-.. _utility-operators:
-
-Utility operators
--------------------
-
-.. csv-table::
-  :header: , Explanation, Example, Notes
+  Without argument, returns a random `RFC 4122 version 4 compliant UUID`__. 
   
-  ., current question's value, . >= 18, Used in :ref:`constraints <constraints>`.
-  \.\., current question's parent group, position(..), Used with :func:`position` to get the iteration index.
+  __ https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)
   
-.. _boolean-operators:
-  
-Boolean operators
-------------------
+  With an argument it returns a random GUID of specified :arg:`length`.  
 
-.. csv-table::
-  :header: , Explanation, Example
+    
+.. function:: boolean(arg) 
 
-  and, ``True`` if the expressions before and after are ``True``, ${age} > -1 and ${age} < 120
-  or, ``True`` if either of the expressions before or after are ``True``, ${age} < 19 or ${age} > 64
+  Returns ``True`` if :arg:`arg` is:
   
-.. _comparion-operators:
+  - a number other than zero
+  - a non-empty string
+  - a non-empty collection
+  - a comparison or expressions that evaluates to ``True``.
+   
+  Returns ``False`` if :arg:`arg` is:
   
-Comparison operators
------------------------
-  
-.. csv-table::
-  :header: , Explanation, Example, Notes
-  
-  =, equal to, ${enrolled} = 'yes', Can compare numbers or strings.
-  !=, not equal to, ${enrolled} != 'yes', Can compare numbers or strings.
-  >, greater than, ${age} > 17, 
-  >=, greater than or equal to, ${age} >= 18,
-  <, less than, ${age} < 65, 
-  <=, less than or equal to, ${age} <= 64,
+  - the number 0
+  - an empty string
+  - an empty collection
+  - a comparison or expression that evaluates to ``False``.
 
-.. _math-operators:
-  
-Math operators
----------------
+    
+.. function:: not(arg)
 
-.. csv-table::
-  :header: , Explanation, Example, Notes
-  
-  \+, addition, ${salary_income} + ${self_employed_income}, Numbers only; does not concatenate strings.
-  \-, subtraction, ${income} - ${expenses},
-  \*, multiplication, ${bill} * 1.18,
-  div, division, ${percent_int} div 100, 
-  mod, `modulo`_ (division remainder), (. mod 2) = 0, 
+  Returns the opposite of :func:`boolean(arg) <boolean>`.
 
-.. _modulo: https://en.wikipedia.org/wiki/Modulo_operation
+  
+.. function:: coalesce(arg, arg) 	
+
+  Returns first non-empty value of the two :arg:`arg`\ s.
+  Returns an empty string if both are empty or non-existent.
+
+.. function:: true()
+
+  Evaluates to ``True``.
+
+.. function:: false()
+
+  Evaluates to ``False``.
+  
+  

--- a/odk1-src/form-functions.rst
+++ b/odk1-src/form-functions.rst
@@ -126,17 +126,18 @@ Control flow
   to identify the current iteration index
   within a repeat group.  
   
-  .. include:: incl/form-examples/parallel-repeat-groups.rst
+  .. container:: details
+  
+    .. include:: incl/form-examples/parallel-repeat-groups.rst
 
 .. function:: once(expression)
 
-  Returns the value :arg:`expression` if the question's value is empty. Otherwise, returns the current value of the question.
+  Returns the value :arg:`expression` if the question's value is empty.
+  Otherwise, returns the current value of the question.
 
   This can be used to ensure that a random number is only generated once,
   or to store the first value entered for a question
-  in a way that is retrievable even of the response is changed later.
-
-    
+  in a way that is retrievable even of the response is changed later.  
 
 .. _response-access-functions:
   
@@ -161,12 +162,16 @@ Select questions
   Returns ``True`` if :arg:`choice_name` 
   was selected in :arg:`select_question`,
   otherwise returns ``False``.
-  
-  .. include:: incl/form-examples/constraint-on-selected.rst
+
+  .. container:: details
+      
+    .. include:: incl/form-examples/constraint-on-selected.rst
   
 .. function:: selected-at(multi_select_question, n)
 
   Returns the :th:`name` of the :arg:`n`\ :sup:`th` selected choice of the :arg:`multi_select_question`. (Selected choices are zero-indexed.)
+  
+  Returns an empty string if the index does not exist.  
   
   .. note::
   
@@ -175,58 +180,60 @@ Select questions
     To get the label in the current language,
     use :func:`jr:choice-name`.
   
-  Returns an empty string if the index does not exist.
+  .. container:: details
   
-  .. image:: /img/form-functions/selected-at-0.* 
-    :alt: A multi-select widget in Collect. The label is "What colors do you like?" Several color names are presented as options. Red, Green, and Purple are selected.
-  
-  .. image:: /img/form-functions/selected-at-1.* 
-    :alt: A note widget in Collect. The label is "Selected Colors". The hint text is "red, green, purple".
-  
-  .. rubric:: XLSForm
-  
-  .. csv-table:: survey
-    :header: type, name, label, hint, calculation
-  
-    select_multiple colors, color_prefs, What colors do you like?, Select three.
-    calculate, color_0, , ,"selected-at(${color_prefs}, 0)"
-    calculate, color_1, , ,"selected-at(${color_prefs}, 1)"
-    calculate, color_2, , ,"selected-at(${color_prefs}, 2)"
-    note, color_note, Selected colors:, ${color_0} <br> ${color_1} <br> ${color_2}  
+    .. image:: /img/form-functions/selected-at-0.* 
+      :alt: A multi-select widget in Collect. The label is "What colors do you like?" Several color names are presented as options. Red, Green, and Purple are selected.
 
-  .. csv-table:: choices
-    :header: list_name, name, label
-    
-    colors, red, Red
-    colors, blue, Blue
-    colors, yellow, Yellow
-    colors, green, Green
-    colors, orange, Orange
-    colors, purple, Purple
+    .. image:: /img/form-functions/selected-at-1.* 
+      :alt: A note widget in Collect. The label is "Selected Colors". The hint text is "red, green, purple".
+
+    .. rubric:: XLSForm
+
+    .. csv-table:: survey
+      :header: type, name, label, hint, calculation
+
+      select_multiple colors, color_prefs, What colors do you like?, Select three.
+      calculate, color_0, , ,"selected-at(${color_prefs}, 0)"
+      calculate, color_1, , ,"selected-at(${color_prefs}, 1)"
+      calculate, color_2, , ,"selected-at(${color_prefs}, 2)"
+      note, color_note, Selected colors:, ${color_0} <br> ${color_1} <br> ${color_2}  
+
+    .. csv-table:: choices
+      :header: list_name, name, label
+
+      colors, red, Red
+      colors, blue, Blue
+      colors, yellow, Yellow
+      colors, green, Green
+      colors, orange, Orange
+      colors, purple, Purple
 
 .. function:: count-selected(multi_select_question)
 
   Returns the number of choices selected in ``multi_select_question``.
   
-  .. image:: /img/form-functions/count-selected-constraint.* 
-    :alt: A multi-select widget in Collect. The label is "What colors do you like?" The hint text is "Select three." Four colors are selected. A message modal overlays the widget with the text "Select exactly three."
+  .. container:: details
   
-  .. rubric:: XLSForm
-  
-  .. csv-table:: survey
-    :header: type, name, label, hint, constraint, constraint_message
-    
-    select_multiple colors, color_prefs, What colors do you like?, Select three., count-selected(.)=3, Select exactly three.
-    
-  .. csv-table:: choices
-    :header: list_name, name, label
-    
-    colors, red, Red
-    colors, blue, Blue
-    colors, yellow, Yellow
-    colors, green, Green
-    colors, orange, Orange
-    colors, purple, Purple
+    .. image:: /img/form-functions/count-selected-constraint.* 
+      :alt: A multi-select widget in Collect. The label is "What colors do you like?" The hint text is "Select three." Four colors are selected. A message modal overlays the widget with the text "Select exactly three."
+
+    .. rubric:: XLSForm
+
+    .. csv-table:: survey
+      :header: type, name, label, hint, constraint, constraint_message
+
+      select_multiple colors, color_prefs, What colors do you like?, Select three., count-selected(.)=3, Select exactly three.
+
+    .. csv-table:: choices
+      :header: list_name, name, label
+
+      colors, red, Red
+      colors, blue, Blue
+      colors, yellow, Yellow
+      colors, green, Green
+      colors, orange, Orange
+      colors, purple, Purple
 
 .. function:: jr:choice-name(choice_name, 'select_question')
 
@@ -239,40 +246,42 @@ Select questions
     .. code-block:: none
     
       '${question_name}'
+      
+  .. container:: details  
   
-  .. image:: /img/form-functions/choice-name-multi-lang-english-0.* 
-    :alt: A multi-select widget in Collect. The label is "What colors do you like?" Several color names are presented as options. Red, Green, and Purple are selected.
-  
-  .. image:: /img/form-functions/choice-name-multi-lang-english-1.* 
-    :alt: A note widget in Collect. The label is "Selected colors". The hint text is "Red, Green, Purple."
-  
-  .. image:: /img/form-functions/choice-name-multi-lang-spanish-0.* 
-    :alt: A multi-select widget in Collect. The label is "¿Qué colores te gustan?" Several color names, in Spanish, are presented as options. Rojo, Verde, and Púrpura are selected.
-    
-  .. image:: /img/form-functions/choice-name-multi-lang-spanish-1.* 
-    :alt: A note widget in Collect. The label is "Colores seleccionados." The hint text is "Rojo, Verde, Púrpura".
-    
-  .. rubric:: XLSForm
-  
-  .. csv-table::  survey
-    :header: type, name, label::English, label::Español, hint::English, hint:Español, calculation
-    
-    select_multiple colors, color_prefs, What colors do you like?, ¿Qué colores te gustan?, Select three., Seleccione tres.
-    calculate, color_0, , , , ,"jr:choice-name( selected-at(${color_prefs}, 0), '${color_prefs}')"
-    calculate, color_1, , , , ,"jr:choice-name( selected-at(${color_prefs}, 2), '${color_prefs}')"
-    calculate, color_2, , , , ,"jr:choice-name( selected-at(${color_prefs}, 2), '${color_prefs}')"
-    note, color_note, Selected colors:, Colores seleccionados:, ${color_0} <br> ${color_1} <br> ${color_2}, ${color_0} <br> ${color_1} <br> ${color_2}
-    
-  .. csv-table:: choices
-    :header: list_name, name, label::English, label::Español
-    
-    colors, red, Red, Rojo
-    colors, blue, Blue, Azul
-    colors, yellow, Yellow, Amarillo
-    colors, green, Green, Verde
-    colors, orange, Orange, Anaranjado
-    colors, purple, Purple, Púrpura
-  
+    .. image:: /img/form-functions/choice-name-multi-lang-english-0.* 
+      :alt: A multi-select widget in Collect. The label is "What colors do you like?" Several color names are presented as options. Red, Green, and Purple are selected.
+
+    .. image:: /img/form-functions/choice-name-multi-lang-english-1.* 
+      :alt: A note widget in Collect. The label is "Selected colors". The hint text is "Red, Green, Purple."
+
+    .. image:: /img/form-functions/choice-name-multi-lang-spanish-0.* 
+      :alt: A multi-select widget in Collect. The label is "¿Qué colores te gustan?" Several color names, in Spanish, are presented as options. Rojo, Verde, and Púrpura are selected.
+
+    .. image:: /img/form-functions/choice-name-multi-lang-spanish-1.* 
+      :alt: A note widget in Collect. The label is "Colores seleccionados." The hint text is "Rojo, Verde, Púrpura".
+
+    .. rubric:: XLSForm
+
+    .. csv-table::  survey
+      :header: type, name, label::English, label::Español, hint::English, hint:Español, calculation
+
+      select_multiple colors, color_prefs, What colors do you like?, ¿Qué colores te gustan?, Select three., Seleccione tres.
+      calculate, color_0, , , , ,"jr:choice-name( selected-at(${color_prefs}, 0), '${color_prefs}')"
+      calculate, color_1, , , , ,"jr:choice-name( selected-at(${color_prefs}, 2), '${color_prefs}')"
+      calculate, color_2, , , , ,"jr:choice-name( selected-at(${color_prefs}, 2), '${color_prefs}')"
+      note, color_note, Selected colors:, Colores seleccionados:, ${color_0} <br> ${color_1} <br> ${color_2}, ${color_0} <br> ${color_1} <br> ${color_2}
+
+    .. csv-table:: choices
+      :header: list_name, name, label::English, label::Español
+
+      colors, red, Red, Rojo
+      colors, blue, Blue, Azul
+      colors, yellow, Yellow, Amarillo
+      colors, green, Green, Verde
+      colors, orange, Orange, Anaranjado
+      colors, purple, Purple, Púrpura
+
 .. _repeat-functions:
     
 Repeat groups
@@ -303,13 +312,17 @@ Repeat groups
 
   .. seealso:: :ref:`referencing-answers-in-repeats`
 
-  .. include:: incl/form-examples/parallel-repeat-groups.rst
+  .. container:: details
+  
+    .. include:: incl/form-examples/parallel-repeat-groups.rst
 
 .. function:: count(nodeset)
 
   Returns the number of items in :arg:`nodeset`. This can be used to count the number of repetitions in a :ref:`repeat group <repeats>`.
 
-  .. include:: incl/form-examples/parallel-repeat-groups.rst
+  .. container:: details
+  
+    .. include:: incl/form-examples/parallel-repeat-groups.rst
   
 .. function:: count-non-empty(nodeset)
 
@@ -321,38 +334,44 @@ Repeat groups
   
   Can be used to :ref:`tally responses to a repeated select question <counting-answers>`.
   
-  .. include::  incl/form-examples/sum-to-count-responses.rst
+  .. container:: details
+  
+    .. include::  incl/form-examples/sum-to-count-responses.rst
 
 .. function:: max(nodeset)
 
   Returns the largest member of :arg:`nodeset`.
   
-  .. rubric:: XLSForm
+  .. container:: details
   
-  .. csv-table:: survey
-    :header: type, name, label, calculation
-    
-    begin_repeat, child_questions, Questions about child
-    text, child_name, Child's name
-    integer, child_age, Child's age
-    end_repeat
-    calculate, age_of_oldest_child, , max(${child_age})
+    .. rubric:: XLSForm
+
+    .. csv-table:: survey
+      :header: type, name, label, calculation
+
+      begin_repeat, child_questions, Questions about child
+      text, child_name, Child's name
+      integer, child_age, Child's age
+      end_repeat
+      calculate, age_of_oldest_child, , max(${child_age})
 
 .. function:: min(nodeset)
 
   Returns the smallest member of :arg:`nodeset`.
-  
-  .. rubric:: XLSForm
-  
-  .. csv-table:: survey
-    :header: type, name, label, calculation
-    
-    begin_repeat, child_questions, Questions about child
-    text, child_name, Child's name
-    integer, child_age, Child's age
-    end_repeat
-    calculate, age_of_youngest_child, , min(${child_age}) 
-  
+
+  .. container:: details 
+   
+    .. rubric:: XLSForm
+
+    .. csv-table:: survey
+      :header: type, name, label, calculation
+
+      begin_repeat, child_questions, Questions about child
+      text, child_name, Child's name
+      integer, child_age, Child's age
+      end_repeat
+      calculate, age_of_youngest_child, , min(${child_age}) 
+
 .. _string-functions:
   
 Strings
@@ -369,8 +388,10 @@ Searching and matching strings
     Returns ``True`` if :arg:`string` is an *exact and complete* match for :arg:`expression`.
 
   .. seealso:: :doc:`form-regex`
-  
-  .. include:: incl/form-examples/regex-middle-initial.rst
+
+  .. container:: details
+    
+    .. include:: incl/form-examples/regex-middle-initial.rst
 
 
 .. function:: contains(string, substring)
@@ -560,39 +581,43 @@ Formatting dates and times for display
   
 .. function:: format-date(date, format)
 
-  Returns :arg:`date` as a string formatted as defined by :arg`format`.
+  Returns :arg:`date` as a string formatted as defined by :arg:`format`.
   
-  The following identifiers are used in the :arg:`format` string:
+  .. container:: details
   
-  .. csv-table::
-  
-    %Y, 4-digit year
-    %y, 2-digit year
-    %m, 0-padded month
-    %n, numeric month
-    %b, "short text month (Jan, Feb, Mar...)" 
-    %d, 0-padded day of month
-    %e, day of month
-    %a, "short text day (Sun, Mon, Tue...)."
+    The following identifiers are used in the :arg:`format` string:
 
-  .. note:: 
-  
-    Month and day abbreviations are language and locale specific. If form locale can be determined, that locale will be used. Otherwise, the device locale will be used.
+    .. csv-table::
+
+      %Y, 4-digit year
+      %y, 2-digit year
+      %m, 0-padded month
+      %n, numeric month
+      %b, "short text month (Jan, Feb, Mar...)" 
+      %d, 0-padded day of month
+      %e, day of month
+      %a, "short text day (Sun, Mon, Tue...)."
+
+    .. note:: 
+    
+      Month and day abbreviations are language and locale specific. If form locale can be determined, that locale will be used. Otherwise, the device locale will be used.
   
 .. function:: format-date-time(dateTime, format)
 
   Returns :arg:`dateTime` as a string formatted as defined by :arg:`format`.
 
-  The identifiers list in :func:`format-date` are available, 
-  plus the following:
+  .. container:: details
   
-  .. csv-table::
-  
-    %H, 0-padded hour (24-hr time)
-    %h, hour (24-hr time)
-    %M, 0-padded minute
-    %S, 0-padded second
-    %3, 0-padded millisecond ticks.
+    The identifiers list in :func:`format-date` are available, 
+    plus the following:
+
+    .. csv-table::
+
+      %H, 0-padded hour (24-hr time)
+      %h, hour (24-hr time)
+      %M, 0-padded minute
+      %S, 0-padded second
+      %3, 0-padded millisecond ticks.
 
 .. _geography-functions:
     

--- a/odk1-src/form-logic.rst
+++ b/odk1-src/form-logic.rst
@@ -258,15 +258,7 @@ For example:
   
 .. seealso:: :doc:`form-regex`  
   
-.. image:: /img/form-logic/constraint-message.* 
-  :alt: A text widget in Collect. The question text is "What is your middle initial?" The entered value is "Michael". Over the widget is an alert message: "Just the first letter."
-  
-.. rubric:: XLSForm
-
-.. csv-table:: survey
-  :header: type, name, label, constraint, constraint_message
-  
-  text, middle_initial, What is your middle initial?, "regex(., '\p{L}')", Just the first letter.
+.. include:: incl/form-examples/regex-middle-initial.rst
   
 .. _read-only:
   
@@ -287,7 +279,7 @@ based on :ref:`previous responses <variables>`.
   decimal, salary_income, Income from salary,,,
   decimal, self_income, Income from self-employment,,,
   decimal, other_income, Other income,,,
-  calculate, income_sum, , , , "sum(${salary_income}, ${self_income}, ${other_income})"
+  calculate, income_sum, , , , "${salary_income} + ${self_income} + ${other_income}"
   decimal, total_income, Total income, yes, ${income_sum}, 
 
     
@@ -316,7 +308,7 @@ Often, comparison `operators`_ are used in relevance expressions. For example:
 :tc:`${has_children} = 'yes'`
   True if the answer to :tc:`has_children` was ``yes``.
   
-Relevance expressions can also use `XPath functions`_.
+Relevance expressions can also use :doc:`XPath functions <form-functions>`.
 For example:
 
 :tc:`selected(${allergies}, 'peanut')`
@@ -330,8 +322,6 @@ For example:
 :tc:`count-selected(${toppings}) > 5`
   True if more than five options were selected
   in the :ref:`multi-select-widget` named :tc:`toppings`.
-
-.. _XPath functions: https://opendatakit.github.io/xforms-spec/#xpath-functions
 
 .. _simple-conditional-example:
 
@@ -360,37 +350,7 @@ Simple example
 Complex example
 ------------------
 
-.. video:: /vid/form-logic/conditional-complex.mp4
-
-.. rubric:: XLSForm
-
-.. csv-table:: survey
-  :header: type, name, label, hint, relevant, constraint
-  
-  select_multiple medical_issues, what_issues, Have you experienced any of the following?, Select all that apply.,,				
-  select_multiple cancer_types, what_cancer, What type of cancer have you experienced?, Select all that apply.,"selected(${what_issues}, 'cancer')",
-  select_multiple diabetes_types, what_diabetes, What type of diabetes do you have?, Select all that apply.,"selected(${what_issues}, 'diabetes')"
-  begin_group, blood_pressure, Blood pressure reading,"selected(${what_issues}, 'hypertension')",
-  integer, systolic_bp, Systolic,,,. > 40 and . < 400
-  integer, diastolic_bp, Diastolic,,,.  >= 20 and . <= 200
-  end_group							
-  text, other_health, List other issues.,,"selected(${what_issues}, 'other')",
-  note,after_health_note, This note is after all health questions.,,,							
-  
-.. csv-table:: choices
-  :header: list_name, name, label
-  
-  medical_issues, cancer, Cancer
-  medical_issues, diabetes, Diabetes
-  medical_issues, hypertension, Hypertension
-  medical_issues, other, Other
-  cancer_types, lung, Lung cancer
-  cancer_types, skin, Skin cancer
-  cancer_types, prostate, Prostate cancer
-  cancer_types, breast, Breast cancer
-  cancer_types, other, Other
-  diabetes_types, type_1, Type 1 (Insulin dependent)
-  diabetes_types, type_2, Type 2 (Insulin resistant)
+.. include:: incl/form-examples/constraint-on-selected.rst
 
 .. warning::
 

--- a/odk1-src/form-logic.rst
+++ b/odk1-src/form-logic.rst
@@ -308,7 +308,7 @@ Often, comparison `operators`_ are used in relevance expressions. For example:
 :tc:`${has_children} = 'yes'`
   True if the answer to :tc:`has_children` was ``yes``.
   
-Relevance expressions can also use :doc:`XPath functions <form-functions>`.
+Relevance expressions can also use :ref:`functions <form-functions>`.
 For example:
 
 :tc:`selected(${allergies}, 'peanut')`

--- a/odk1-src/form-operators-functions.rst
+++ b/odk1-src/form-operators-functions.rst
@@ -29,7 +29,7 @@
   
 	
 ******************************
-Form Functions and Operators
+Form Operators and Functions
 ******************************
 
 :ref:`expressions` in :ref:`calculations <calculations>`, :ref:`constraints <constraints>`, and :ref:`relevants <relevants>`

--- a/odk1-src/form-operators-functions.rst
+++ b/odk1-src/form-operators-functions.rst
@@ -4,6 +4,7 @@
   Azul
   Colores
   Español
+  Nodesets
   Púrpura
   Qué
   Rojo
@@ -34,53 +35,14 @@ Form Functions and Operators
 :ref:`expressions` in :ref:`calculations <calculations>`, :ref:`constraints <constraints>`, and :ref:`relevants <relevants>`
 can contain operators and functions.
 
-.. seealso:: `XPath Functions <https://opendatakit.github.io/xforms-spec/#xpath-functions>`_
-
 .. contents::
   :local:   
-
-  
-.. _xform-operators:
+  :depth: 2
+    
+.. _form-operators:
 
 Operators
 ==========
-
-.. _utility-operators:
-
-Utility operators
--------------------
-
-.. csv-table::
-  :header: , Explanation, Example, Notes
-  
-  ., current question's value, . >= 18, Used in :ref:`constraints <constraints>`.
-  \.\., current question's parent group, position(..), Used with :func:`position` to get the iteration index.
-  
-.. _boolean-operators:
-  
-Boolean operators
-------------------
-
-.. csv-table::
-  :header: , Explanation, Example
-
-  and, ``True`` if the expressions before and after are ``True``, ${age} > -1 and ${age} < 120
-  or, ``True`` if either of the expressions before or after are ``True``, ${age} < 19 or ${age} > 64
-  
-.. _comparison-operators:
-  
-Comparison operators
------------------------
-  
-.. csv-table::
-  :header: , Explanation, Example, Notes
-  
-  =, equal to, ${enrolled} = 'yes', Can compare numbers or strings.
-  !=, not equal to, ${enrolled} != 'yes', Can compare numbers or strings.
-  >, greater than, ${age} > 17, 
-  >=, greater than or equal to, ${age} >= 18,
-  <, less than, ${age} < 65, 
-  <=, less than or equal to, ${age} <= 64,
 
 .. _math-operators:
   
@@ -99,11 +61,69 @@ Math operators
 .. _modulo: https://en.wikipedia.org/wiki/Modulo_operation
 
   
+.. _comparison-operators:
   
-.. _functions:
+Comparison operators
+-----------------------
+  
+Comparison operators are used to compare values.
+The result of a comparison is always ``True`` or ``False``.
+  
+.. csv-table::
+  :header: , Explanation, Example, Notes
+  
+  =, equal to, ${enrolled} = 'yes', Can compare numbers or strings.
+  !=, not equal to, ${enrolled} != 'yes', Can compare numbers or strings.
+  >, greater than, ${age} > 17, 
+  >=, greater than or equal to, ${age} >= 18,
+  <, less than, ${age} < 65, 
+  <=, less than or equal to, ${age} <= 64,
+  
+.. _boolean-operators:
+  
+Boolean operators
+------------------
+
+Boolean operators combine two ``True`` or ``False`` values
+into a single ``True`` or ``False`` value.
+
+.. csv-table::
+  :header: , Explanation, Example
+
+  and, ``True`` if the expressions before and after are ``True``, ${age} > -1 and ${age} < 120
+  or, ``True`` if either of the expressions before or after are ``True``, ${age} < 19 or ${age} > 64
+
+
+.. _path-operators:
+
+Path operators
+-------------------
+
+.. csv-table::
+  :header: , Explanation, Example, Notes
+  
+  ., current question's value, . >= 18, Used in :ref:`constraints <constraints>`.
+  \.\., current question's parent group, position(..), Used with :func:`position` to get the iteration index.
+
+.. note:: 
+
+  Formally, these are not operators but rather XPath references 
+  to the current node (``..``) and the containing node (``.``). 
+  `XPath paths`_ can be used to reference nodes of a form.
+  
+  .. _XPath paths: https://opendatakit.github.io/xforms-spec/#xpath-paths
+    
+  
+.. _form-functions:
   
 Functions
 ===========
+
+.. contents::
+  :local:
+    
+.. seealso:: `Functions in the ODK XForm Specification <https://opendatakit.github.io/xforms-spec/#xpath-functions>`_
+
     
 .. _control-flow-functions:
 
@@ -157,25 +177,39 @@ Accessing response values
 Select questions
 ~~~~~~~~~~~~~~~~~~~
 
-.. function:: selected(select_question, choice_name)
+.. function:: selected(space_delimited_array, string)
 
-  Returns ``True`` if :arg:`choice_name` 
-  was selected in :arg:`select_question`,
+  Returns ``True`` if :arg:`string` 
+  is a member of :arg:`space_delimited_array`,
   otherwise returns ``False``.
+  
+  Commonly used to determined if a specific choice was selected
+  in a :ref:`select question <select-widgets>`. 
+  (This is possible because 
+  a :ref:`reference to <variables>` a select question
+  returns a space-delimited array of choice names.)
 
   .. container:: details
       
     .. include:: incl/form-examples/constraint-on-selected.rst
   
-.. function:: selected-at(multi_select_question, n)
+.. function:: selected-at(space_delimited_array, n)
 
-  Returns the :th:`name` of the :arg:`n`\ :sup:`th` selected choice of the :arg:`multi_select_question`. (Selected choices are zero-indexed.)
-  
+  Returns the string at the :arg:`n`\ :sup:`th` position 
+  of the :arg:`space_delimited_array`.
+  (The array is zero-indexed.)
   Returns an empty string if the index does not exist.  
+  
+  This can be used to get the :th:`name` of a selected choice 
+  from a :ref:`multi-select question <multi-select-widget>`.
+  (This is possible because 
+  a :ref:`reference to <variables>` a select question
+  returns a space-delimited array of choice names.)
   
   .. note::
   
-    This function returns the :th:`name`, not the :th:`label`,
+    If used to get a choice name from a select question,
+    this function returns the :th:`name`, not the :th:`label`,
     of the selected choice.
     To get the label in the current language,
     use :func:`jr:choice-name`.
@@ -294,11 +328,14 @@ Repeat groups
 
     nodeset
 
-      A collection of response values. 
+      A collection of XML nodes.
+      In XLSForms, this is typically a collection of response values. 
 
       Outside a :ref:`repeat group <repeats>`, 
       :ref:`referring to a question by name <variables>`
       will return a nodeset containing all the responses to that question.
+      
+      Nodesets can also be created by joining two or more nodes with pipes: :tc:`/data/age | /data/name`.
 
         
 .. function:: indexed-repeat(name, group, i [, sub_grp, sub_i [, sub_sub_grp, sub_sub_i ]])
@@ -439,11 +476,6 @@ Converting to and from strings
   Returns ``True`` if :arg:`string` is "true" or "1".
   Otherwise, ``False``.
 
-
-.. function:: number(string)
-
-  Converts a :arg:`string` of digits into a number value.
-
 .. function:: string(arg)
 
    Converts :arg:`arg` to a string.
@@ -462,10 +494,21 @@ Number handling
 
   Rounds a decimal :arg:`number` to some number of decimal :arg:`places`.
 
-.. function:: int(arg) 	
+.. function:: int(number) 	
 
-  Converts :arg:`arg` to an integer.
+  Truncates the fractional portion of a decimal :arg:`number` to return an integer.
 
+.. function:: number(arg)
+
+  Converts :arg:`arg` to number value.
+  
+  If :arg:`arg` is a string of digits, returns the number value.
+  
+  If :arg:`arg` is ``True``, returns 1. If :arg:`arg` is ``False``, returns 0.
+  
+  If :arg:`arg` cannot be converted, returns ``NaN`` (not a number).
+
+  
 .. seealso:: :func:`count`, :func:`max`, :func:`min`, :func:`number`
   
 .. _calculation-functions:
@@ -545,7 +588,9 @@ Date and time
 
 .. function:: now()
 
-  Returns the current datetime in the current time zone.
+  Returns the current datetime in `ISO 8601 format`_, including the timezone.
+  
+  .. _ISO 8601 format: https://en.wikipedia.org/wiki/ISO_8601
 
 .. _date-time-conversion-functions:
   
@@ -570,7 +615,7 @@ Converting dates and time
 .. function:: decimal-time(time)
 
   Converts :arg:`time` to a number representing a fractional day.
-  For example, noon is 0.5 and 6pm is 0.75.
+  For example, noon is 0.5 and 6:00 PM is 0.75.
 
 
 .. _date-time-formatting-functions:
@@ -655,22 +700,19 @@ Utility
 
   Returns a shuffled :arg:`nodeset`.
   
-  A shuffle with a numeric :arg:`seed` is deterministic and reproducible.
+  A shuffle with a numeric :arg:`seed` is deterministic and reproducible. 
   
-.. function:: checklist(min, max, response[, response[, response [, ... ]]])
-
-  Returns ``True`` if the number of :arg:`response`\ s that are exactly the string "yes" is between :arg:`min` and :arg:`max`, inclusive.  
+  .. tip::
   
-  Set :arg:`min` or :arg:`max` to ``-1`` to make the argument not applicable.
-
-.. function:: weighted-checklist(min, max, reponse, weight[, response, weight[, response, weight[, response, weight[, ... ]]])
-
-  Returns ``True`` if 
-  the sum of the :arg:`weight`\ s 
-  of each :arg:`response` that is exactly the string "yes"
-  is between :arg:`min` and :arg:`max`, inclusive.
-  
-  Set :arg:`min` or :arg:`max` to ``-1`` to make the argument not 
+    You may want to generate and store a :arg:`seed` in a previous :ref:`calculate <calculations>` row, so you have a reproducible log of how a nodeset was randomized. Use :func:`once` to make sure the value doesn't change after being set.
+    
+    .. rubric:: XLSForm
+    
+    .. csv-table:: survey
+      :header: type, name, calculation
+      
+      calculate, seed_1, once(random())
+      calculate, shuffled_set, randomize(${some_nodeset}, ${seed_1})
     
 .. function:: uuid([length]) 	
 
@@ -708,6 +750,23 @@ Utility
   Returns first non-empty value of the two :arg:`arg`\ s.
   Returns an empty string if both are empty or non-existent.
 
+  
+.. function:: checklist(min, max, response[, response[, response [, ... ]]])
+
+  Returns ``True`` if the number of :arg:`response`\ s that are exactly the string "yes" is between :arg:`min` and :arg:`max`, inclusive.  
+  
+  Set :arg:`min` or :arg:`max` to ``-1`` to make the argument not applicable.
+
+.. function:: weighted-checklist(min, max, reponse, weight[, response, weight[, response, weight[, response, weight[, ... ]]])
+
+  Returns ``True`` if 
+  the sum of the :arg:`weight`\ s 
+  of each :arg:`response` that is exactly the string "yes"
+  is between :arg:`min` and :arg:`max`, inclusive.
+  
+  Set :arg:`min` or :arg:`max` to ``-1`` to make the argument not 
+
+  
 .. function:: true()
 
   Evaluates to ``True``.

--- a/odk1-src/form-repeats.rst
+++ b/odk1-src/form-repeats.rst
@@ -108,24 +108,6 @@ To reference a response from a later iteration,
 or from outside the loop,
 use :func:`indexed-repeat` and :func:`position`.
   
-.. function:: indexed-repeat(name, group, i [, sub_grp, sub_i [, sub_sub_grp, sub_sub_i [...]]])
-
-  Returns the response value of question ``name``
-  from the repeat-group ``group``,
-  in iteration ``i``.
-  
-  Nested repeat groups can be accessed 
-  using the ``sub`` and ``sub_sub`` parameters,
-  which can be extended indefinitely
-  to arbitrary levels of nesting.
-  
-.. function:: position(xpath)
-
-  Returns an integer equal to the position of the current node
-  within the node defined by ``xpath``.
-  
-  Most often this is used in the form ``position(..)``
-  to identify the current iteration index.
 
 
 .. _referencing-responses-from-outside-repeat-loop:
@@ -155,20 +137,7 @@ This can be done by using `count()` and `position(..)`
 to iterate through a repeat group 
 in a second repeat group.
 
-.. rubric:: XLSForm
-
-.. csv-table::
-  :header: type, name, label, repeat_count, calculation
-    
-  note, person_list_note, Please list the names of the people in your household.,,
-  begin_repeat, name_group, Member of household, ,
-  text, name, Name, ,
-  end_repeat,,,,
-  begin_repeat, member_details, Details, count(${name}) ,
-  calculate, current_name, , , "indexed-repeat(${name}, ${name-group}, position(..))"
-  date, member_bday, Birthday of ${current_name},,
-  end_repeat,,,, 
-  
+.. include:: incl/form-examples/parallel-repeat-groups.rst
 
 .. _counting-repeats-and-answers:
 
@@ -202,25 +171,4 @@ which evaluates to ``1`` or ``0`` depending on the answer.
 Then, outside the loop,
 calculate the :tc:`sum()` of the calculate field.
 
-.. rubric:: XLSForm
-
-.. csv-table:: survey
-  :header: type, name, label, calculation
-  
-  begin_repeat, guest_details, Guest details
-  text, guest_name, Guest name
-  select_one meal_options, meal_preference, Meal preference
-  calculate, chkn, , "if(${meal_preference} == 'chicken', 1, 0 )"
-  calculate, fsh, , "if(${meal_preference} == 'fish', 1, 0 )"
-  calculate, veg, , "if(${meal_preference} == 'vegetarian', 1, 0 )"
-  end_repeat
-  calculate, chkn_count, , sum(${chkn})
-  calculate, fsh_count, , sum(${fsh})
-  calculate, veg_count, , sum(${veg})
- 
-.. csv-table:: choices
-  :header: list_name, name, label
-  
-  meal_options, chicken, Chicken
-  meal_options, fish, Fish
-  meal_options, vegetarian, Vegetarian
+.. include::  incl/form-examples/sum-to-count-responses.rst

--- a/odk1-src/img/form-functions/choice-name-multi-lang-english-0.png
+++ b/odk1-src/img/form-functions/choice-name-multi-lang-english-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ed4fea3ad6256da54c509412176084deb1f1d09509e1faa10e601ebdb4c94a5
+size 99563

--- a/odk1-src/img/form-functions/choice-name-multi-lang-english-1.png
+++ b/odk1-src/img/form-functions/choice-name-multi-lang-english-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8385d0f77c396d1ba83b596f3fcb43cb6234434d1ec8b78a87b77ac2e691e1fb
+size 71953

--- a/odk1-src/img/form-functions/choice-name-multi-lang-spanish-0.png
+++ b/odk1-src/img/form-functions/choice-name-multi-lang-spanish-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c75fe59261215793185bd38538235ca25cae247cd3fc5a159193b37b2c9a226
+size 96062

--- a/odk1-src/img/form-functions/choice-name-multi-lang-spanish-1.png
+++ b/odk1-src/img/form-functions/choice-name-multi-lang-spanish-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b03c71e587ebddd457bf227ba25aceb19a8781b91a03eaf08fc371dee04aab9
+size 67988

--- a/odk1-src/img/form-functions/count-selected-constraint.png
+++ b/odk1-src/img/form-functions/count-selected-constraint.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29577d44851219af33f5e2dc6f8c21877b1ceec4dc17cd6788f21123a27a7ebd
+size 108401

--- a/odk1-src/img/form-functions/selected-at-0.png
+++ b/odk1-src/img/form-functions/selected-at-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd8681110e0b52b3a892e7a6a09e3d469c17c635649bfa99a2295bea1b1ecde5
+size 97304

--- a/odk1-src/img/form-functions/selected-at-1.png
+++ b/odk1-src/img/form-functions/selected-at-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d002d0cfc82c073d7a509d0f24bcb7e51f5a8fc5bddd2fb1b1198edbe69dbaa
+size 68176

--- a/odk1-src/incl/form-examples/constraint-on-selected.rst
+++ b/odk1-src/incl/form-examples/constraint-on-selected.rst
@@ -1,0 +1,33 @@
+.. video:: /vid/form-logic/conditional-complex.mp4
+
+  Video showing a series of select questions. The questions displayed change depending on what choices are selected in th first questions.
+
+.. rubric:: XLSForm
+
+.. csv-table:: survey
+  :header: type, name, label, hint, relevant, constraint
+  
+  select_multiple medical_issues, what_issues, Have you experienced any of the following?, Select all that apply.,,				
+  select_multiple cancer_types, what_cancer, What type of cancer have you experienced?, Select all that apply.,"selected(${what_issues}, 'cancer')",
+  select_multiple diabetes_types, what_diabetes, What type of diabetes do you have?, Select all that apply.,"selected(${what_issues}, 'diabetes')"
+  begin_group, blood_pressure, Blood pressure reading,"selected(${what_issues}, 'hypertension')",
+  integer, systolic_bp, Systolic,,,. > 40 and . < 400
+  integer, diastolic_bp, Diastolic,,,.  >= 20 and . <= 200
+  end_group							
+  text, other_health, List other issues.,,"selected(${what_issues}, 'other')",
+  note,after_health_note, This note is after all health questions.,,,							
+  
+.. csv-table:: choices
+  :header: list_name, name, label
+  
+  medical_issues, cancer, Cancer
+  medical_issues, diabetes, Diabetes
+  medical_issues, hypertension, Hypertension
+  medical_issues, other, Other
+  cancer_types, lung, Lung cancer
+  cancer_types, skin, Skin cancer
+  cancer_types, prostate, Prostate cancer
+  cancer_types, breast, Breast cancer
+  cancer_types, other, Other
+  diabetes_types, type_1, Type 1 (Insulin dependent)
+  diabetes_types, type_2, Type 2 (Insulin resistant)

--- a/odk1-src/incl/form-examples/parallel-repeat-groups.rst
+++ b/odk1-src/incl/form-examples/parallel-repeat-groups.rst
@@ -1,0 +1,14 @@
+.. rubric:: XLSForm
+
+.. csv-table::
+  :header: type, name, label, repeat_count, calculation
+    
+  note, person_list_note, Please list the names of the people in your household.,,
+  begin_repeat, name_group, Member of household, ,
+  text, name, Name, ,
+  end_repeat,,,,
+  begin_repeat, member_details, Details, count(${name}) ,
+  calculate, current_name, , , "indexed-repeat(${name}, ${name-group}, position(..))"
+  date, member_bday, Birthday of ${current_name},,
+  end_repeat,,,, 
+  

--- a/odk1-src/incl/form-examples/regex-middle-initial.rst
+++ b/odk1-src/incl/form-examples/regex-middle-initial.rst
@@ -1,0 +1,9 @@
+.. image:: /img/form-logic/constraint-message.* 
+  :alt: A text widget in Collect. The question text is "What is your middle initial?" The entered value is "Michael". Over the widget is an alert message: "Just the first letter."
+  
+.. rubric:: XLSForm
+
+.. csv-table:: survey
+  :header: type, name, label, constraint, constraint_message
+  
+  text, middle_initial, What is your middle initial?, "regex(., '\p{L}')", Just the first letter.

--- a/odk1-src/incl/form-examples/sum-to-count-responses.rst
+++ b/odk1-src/incl/form-examples/sum-to-count-responses.rst
@@ -1,0 +1,22 @@
+.. rubric:: XLSForm
+
+.. csv-table:: survey
+  :header: type, name, label, calculation
+  
+  begin_repeat, guest_details, Guest details
+  text, guest_name, Guest name
+  select_one meal_options, meal_preference, Meal preference
+  calculate, chkn, , "if(${meal_preference} == 'chicken', 1, 0 )"
+  calculate, fsh, , "if(${meal_preference} == 'fish', 1, 0 )"
+  calculate, veg, , "if(${meal_preference} == 'vegetarian', 1, 0 )"
+  end_repeat
+  calculate, chkn_count, , sum(${chkn})
+  calculate, fsh_count, , sum(${fsh})
+  calculate, veg_count, , sum(${veg})
+ 
+.. csv-table:: choices
+  :header: list_name, name, label
+  
+  meal_options, chicken, Chicken
+  meal_options, fish, Fish
+  meal_options, vegetarian, Vegetarian

--- a/odk1-src/index.rst
+++ b/odk1-src/index.rst
@@ -74,6 +74,7 @@ For a complete list of our projects, check out `Open Data Kit on Github <https:/
   form-question-types
   form-logic
   form-styling
+  form-functions
   form-audit-log
   launch-apps-from-collect
   form-tools

--- a/odk1-src/index.rst
+++ b/odk1-src/index.rst
@@ -74,7 +74,7 @@ For a complete list of our projects, check out `Open Data Kit on Github <https:/
   form-question-types
   form-logic
   form-styling
-  form-functions
+  form-operators-functions
   form-audit-log
   launch-apps-from-collect
   form-tools

--- a/video.py
+++ b/video.py
@@ -25,7 +25,9 @@ class video_node(nodes.General, nodes.Element): pass
 
 def visit_video_html(self, node):
 
-    srcPath = node["source_dir"] + "%s"
+    srcPath = node["source_dir"].split('incl',1)[0] + "%s" 
+        # .split() removes everything after 'incl'
+        # so video files will only be looked for in the root dir
     vsrc = node["uri"]
     spth = srcPath % vsrc
 


### PR DESCRIPTION
#### What is included in this PR?

 - Function and operator reference
 - Reusable form examples pulled into includes
 - conf.py updated to use JS domain by default (See below)
 - custom css to make function reference easier to read
 - fixed a few form examples (form-logic and form-repeats) that were either wrong or had typos

#### What issues need to be opened?

Opening an ongoing issue to add useful examples.

#### Any problems?

##### Minor - Hard to follow existing references

A few of the functions listed in the XForm spec weren't clear, and a few weren't relevant --- tracking that down was a minor pain.

cf: https://opendatakit.github.io/xforms-spec/#xpath-functions

##### Sort of major - Domain work

In Sphinx, function references like this are done using language specific domains.
 cf: http://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html

There is no XForm/XPath domain. I tried using the default domain (Python), but the syntax didn't work out. (Python doesn't allow hyphens, and does namespacing differently.) Then I tried to write my own domain, using the Python domain as a starting point. This was a terrible mistake.

Finally, I discovered that the JS domain was *good enough* for current purposes. So `conf.py` has been updated to use that as the default. It might become a problem in the future, depending on how much more XForm/Xpath stuff makes it into the docs. Also, it may become an issue if we decide to pull the ODK XForm spec into Sphinx.

##### Sidenote problem -- git rebase

I did the following:

 - rebased all my work on top of a fresh pull of master
 - fixed conflicts
 - commited locally
 - pushed to GH (--force)

And I *still* had to come fix a merge conflict (The same one) here in GH. There's something in this rebase process I'm missing. It wasn't a big deal, but it's a little annoying.  