### PR TITLE
add tip on default workaround

### DIFF
--- a/odk1-src/form-logic.rst
+++ b/odk1-src/form-logic.rst
@@ -211,6 +211,9 @@ Setting default responses
 To provide a default response to a question,
 put the response value in the :th:`default` column.
 
+Default values must be static values,
+not expressions or variables.
+
 .. rubric:: XLSForm
 
 .. csv-table:: survey
@@ -224,6 +227,22 @@ put the response value in the :th:`default` column.
   contacts, phone_call, Phone call
   contacts, text_message, Text message
   contacts, email, Email
+  
+.. tip:: 
+
+  You may want to use a previously entered value as a default,
+  but the :th:`default` column does not accept dynamic values.
+  
+  To workaround this, use the :th:`calculation` column instead,
+  and wrap your default value expression in a :func:`once` function.
+  
+  .. rubric:: XLSForm
+  
+  .. csv-table:: survey
+    :header: type, name, label, calculation
+    
+    text, default_value, Enter any text.,
+    text, calculated_default, Leave the value or change it., once(${default_value})
   
 .. _constraints:
 


### PR DESCRIPTION
closes #664

#### What is included in this PR?

 - added a line about static values only in defaults
 - added a tip section with a workaround and simple example


#### What is left to be done in the addressed issue?

I'm not sure if it is needed, but --- @lognaturel's original example was much more complicated. I simplified to just calling a simple variable in `once()`. This works (as far as I can tell). I don't know if a more complicated example is definitely needed. It might be helpful... but I found the more complicated example very confusing.