### PR TITLE
Remove html

### DIFF
--- a/odk1-src/form-styling.rst
+++ b/odk1-src/form-styling.rst
@@ -165,13 +165,13 @@ you'll need to escape that too.
   
   note, escape_md, \# This headline is normal sized, \*Asterisks\* and \_underscores\_ and one slash: \\
   
-.. _style-attribute:
+.. _custom-styling:
   
-Styling with the style attribute
+Custom styling
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To add custom styling to hint, label, and choice labels,
-use `the style attribute`_.
+use `the style attribute`_ on a :tc:`span` tag.
 The :tc:`style` attribute accepts CSS-like key-value pairs for setting color and font-family.
 
 .. _the style attribute: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/style 

--- a/odk1-src/form-styling.rst
+++ b/odk1-src/form-styling.rst
@@ -15,7 +15,7 @@ Form Styling
 
 Labels, hints, and choices in an :doc:`xlsform`
 can all be styled using 
-:ref:`markdown-in-forms`, :ref:`html-in-forms`, and :ref:`emoji`.
+:ref:`markdown-in-forms` and :ref:`emoji`.
 
 
 .. _markdown-in-forms:
@@ -164,52 +164,6 @@ you'll need to escape that too.
   :header: type, name, label, hint
   
   note, escape_md, \# This headline is normal sized, \*Asterisks\* and \_underscores\_ and one slash: \\
-  
-  
-.. _html-in-forms:
-  
-HTML
------
-
-Collect forms support `a subset of HTML elements`__.
-
-__ https://www.grokkingandroid.com/android-quick-tip-formatting-text-with-html-fromhtml/
-
-.. csv-table::
-  :header: tag, format
-  
-  ":tc:`<b>`", bold
-  ":tc:`<i>`", italic
-  ":tc:`<u>`", underline
-  ":tc:`<sub>`", subtext
-  ":tc:`<sup>`", supertext
-  ":tc:`<big>`", big
-  ":tc:`<small>`", small
-  ":tc:`<tt>`", monospace (teletype)
-  ":tc:`<h1>,<h2>,<h3>,<h4>,<h5>,<h6>`", headlines
-  ":tc:`<font>`", font face and color
-  ":tc:`<blockquote>`", for longer quotes
-  ":tc:`<a>`", link
-  ":tc:`<p>`", paragraph
-  ":tc:`<br>`", line break
-  ":tc:`<span>`", "span (generic inline element, used for styling)"
-  
-.. warning::
-
-  `Enketo`_ does not support HTML in forms.
-  For Enketo compatibility,
-  stick to :ref:`markdown-in-forms`.
-  
-  .. _Enketo: https://enketo.org/
-  
-.. image:: /img/form-styling/html-styling.* 
-  :alt: A note widget in Collect. The Label text is "Label heading (line break) If you need a headline and additional text, use HTML instead of Markdown." The words "Label heading" are styled as a large headline. The hint text is "Hint text can have bold, italic, and underlined words. Words can be raised with superscript or lowered with subscript. Use tt for monospace." The words "bold", "italic", "underlined", "superscript", "subscript", and "monospace" are each styled as described.
-  
-.. csv-table:: survey
-  :header: type, name, label, hint
-  
-  note,	html, "<h2>Label heading</h2><p>If you need a headline and additional text, use HTML instead of Markdown.</p>", <p>Hint text can have <b>bold</b>, <i>italic</i>, and <u>underlined</u> words. Words can be raised with <sup>superscript</sup> or lowered with <sub>subscript</sub>. Use <tt>tt</tt> for <tt>monospace</tt>."
-
   
 .. _style-attribute:
   


### PR DESCRIPTION
Addresses #699

#### What is included in this PR?
Remove the HTML docs
Reword the section title on custom styling

#### What is left to be done in the addressed issue?
* Remove the H*s in all-headers-label section. Maybe just drop the screenshot and show an example of an H6 and let the user fill in the blanks.
* Remove the H1 in Color and font styling can be combined
* Adjust style-example.xlsx to remove any HTML. Even the <br>, but I think newlines there should work. I hope.

@adammichaelwood There will be a tweet about styling going out on Monday, so ideally we can merge this as soon as possible and do the rest in a follow-on PR?