### PR TITLE
adds file widget

### DIFF
--- a/odk1-src/form-question-types.rst
+++ b/odk1-src/form-question-types.rst
@@ -1521,6 +1521,10 @@ Records video, using the device camera.
 File upload widget
 --------------------
 
+.. versionadded:: 1.15
+
+  `ODK Collect v1.15.0 <https://github.com/opendatakit/collect/releases/tag/v1.15.0>`_
+
 Uploads any file from the device to the form.
 
 .. image:: /img/form-question-types/file-upload-widget.* 

--- a/odk1-src/form-question-types.rst
+++ b/odk1-src/form-question-types.rst
@@ -1516,6 +1516,31 @@ Records video, using the device camera.
   video, blinking, Please record a video of yourself blinking., Three times is probably sufficient.
 
 
+.. _file-upload:
+
+File upload widget
+--------------------
+
+Uploads any file from the device to the form.
+
+.. image:: /img/form-question-types/file-upload-widget.* 
+  :alt: The file upload widget in Collect.
+       The question label is "Select a file to upload."
+       Below that is a button labeled "Choose File".
+       
+.. image:: /img/form-question-types/file-upload-open-from.* 
+  :alt: A  file selection screen on an Android device.
+	A sidebar overlay is labeled "Open from".
+	This sidebar has several file locations such as "Recent", "Google Drive", "Images", "Downloads".
+
+.. rubric:: XLSForm
+
+.. csv-table:: survey
+  :header: type, name, label
+
+  file, some-file, Select a file to upload.
+
+  
 .. _barcode:
 
 Barcode widget

--- a/odk1-src/img/form-question-types/file-upload-open-from.png
+++ b/odk1-src/img/form-question-types/file-upload-open-from.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:838f48b7da9f998147fcfc8babdf2c14c579d3f33986fb90cdc6cdf4867b0ff4
+size 55358

--- a/odk1-src/img/form-question-types/file-upload-widget.png
+++ b/odk1-src/img/form-question-types/file-upload-widget.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a5fea4d303f53923f5635e4335834a8ba8ed4630884f29a10a4757edd6539e1
+size 39121


### PR DESCRIPTION
closes #667 



#### What is included in this PR?

A new widget section for the file widget.

#### What is left to be done in the addressed issue?

[This conversation about Pyxform support](https://github.com/XLSForm/pyxform/issues/194) and the [PR that satisfies it](https://github.com/XLSForm/pyxform/pull/198) suggests that a form designer could specify allowed file types, but I can't find an example of how it would be done. The PR includes a sample XLSX file, but it doesn't specify any file types.

#### Note --- this is a new feature

This PR should not be pushed until the associated Collect and Pyxform features are released.