### PR TITLE
adds -W to make

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
             sudo python style-test.py $paths -r shared-src
       - run:
           name: Build ODK1 Documentation
-          command: make odk1
+          command: make odk1-deploy
       - run:
           name: Check spelling of ODK1 Documentation
           command: make odk1-spell-check
@@ -100,7 +100,7 @@ jobs:
             sudo python style-test.py $paths -r shared-src
       - run:
           name: Build ODK2 Documentation
-          command: make odk2
+          command: make odk2-deploy
       - run:
           name: Check spelling of ODK2 Documentation
           command: make odk2-spell-check

--- a/Makefile
+++ b/Makefile
@@ -46,12 +46,18 @@ odk2_copy: odk2_clean_files
 	mkdir $(COMPILE2_SRCDIR)
 	cp -rf $(ODK2_SRCDIR)/* $(COMPILE2_SRCDIR)
 	cp -rf $(SHARED_SRCDIR)/* $(COMPILE2_SRCDIR)
-	
+
 odk1: odk1_copy
 	@$(SPHINXBUILD) -b dirhtml "$(COMPILE1_SRCDIR)" "$(ODK1_BUILDDIR)" $(SPHINXOPTS)
 
 odk2: odk2_copy
 	@$(SPHINXBUILD) -b dirhtml "$(COMPILE2_SRCDIR)" "$(ODK2_BUILDDIR)" $(SPHINXOPTS)
+
+odk1-deploy: odk1_copy
+	@$(SPHINXBUILD) -W -b dirhtml "$(COMPILE1_SRCDIR)" "$(ODK1_BUILDDIR)" $(SPHINXOPTS)
+
+odk2-deploy: odk2_copy
+	@$(SPHINXBUILD) -W -b dirhtml "$(COMPILE2_SRCDIR)" "$(ODK2_BUILDDIR)" $(SPHINXOPTS)
 
 build-all: odk1 odk2
 
@@ -69,7 +75,7 @@ odk1-style-check: odk1
 odk1-spell-check: odk1
 	sphinx-build -b spelling $(COMPILE1_SRCDIR) $(ODK1_BUILDDIR)/spelling
 	python util/check-spelling-output.py $(ODK1_BUILDDIR)
-	
+
 odk2-style-check: odk2
 	python style-test.py -r $(COMPILE2_SRCDIR)
 


### PR DESCRIPTION
closes #721 

#### What is included in this PR?

Adds two new make commands:
`make odk1-deploy`
`make odk2-deploy`

These are the same as the `odk*` versions, but with the addition of the `-W` flag,
to raise Warnings as Errors.

Then, `.circleci/config.yml` is updated to use the `-deploy` versions.

#### NOTE: If this works, it should cause a build error.

Until #720 is merged, this branch contains a broken ref, which should now trigger a build error.
