### PR TITLE
change selfie to new front

### DIFF
--- a/odk1-src/form-question-types.rst
+++ b/odk1-src/form-question-types.rst
@@ -1397,15 +1397,20 @@ An image widget that does not include a :guilabel:`Choose Image` button. This re
   
 .. _selfie-widget:
 
-Selfie widget
-~~~~~~~~~~~~~~~
+Self portrait (*selfie*) widget
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 type
   :tc:`image`
 appearance
-  :tc:`selfie`
+  :tc:`new-front`
 
 Takes a picture using the front-facing ("selfie") camera. The :guilabel:`Choose image` button is not displayed.
+
+.. versionchanged:: 1.15
+
+  Prior to v.1.15, the appearance attribute for this was :tc:`selfie`.
+  The old appearance attribute will continue to work on existing forms, but new forms should use the :tc:`new-front` appearance.
 
 .. image:: /img/form-widgets/selfie-start.*
   :alt: The Selfie form widget, as displayed in the ODK Collect app on an Android phone. The question text is, "Selfie widget." The hint text is, "image type with selfie appearance." There is a single button, labeled "Take Picture." Above the question text is the form group name "Image widgets."
@@ -1421,7 +1426,7 @@ Takes a picture using the front-facing ("selfie") camera. The :guilabel:`Choose 
 .. csv-table:: survey
   :header: type, name, label, appearance, hint
 
-  image,selfie_image_widget,Selfie widget,selfie,image type with selfie appearance
+  image,selfie_image_widget,Selfie widget,new-front,image type with new-front appearance
 
 
 .. _draw-widget:

--- a/odk1-src/form-question-types.rst
+++ b/odk1-src/form-question-types.rst
@@ -1395,7 +1395,7 @@ An image widget that does not include a :guilabel:`Choose Image` button. This re
   image, image_widget_no_choose, Image widget without Choose button, new, image type with new appearance (can also be added with annotate appearance and on audio and video types)
   
   
-.. _selfie-widget:
+.. _self-portrait-widget:
 
 Self portrait (*selfie*) widget
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1409,24 +1409,27 @@ Takes a picture using the front-facing ("selfie") camera. The :guilabel:`Choose 
 
 .. versionchanged:: 1.15
 
-  Prior to v.1.15, the appearance attribute for this was :tc:`selfie`.
+  Prior to v1.15, the appearance attribute for this was :tc:`selfie`.
   The old appearance attribute will continue to work on existing forms, but new forms should use the :tc:`new-front` appearance.
 
-.. image:: /img/form-widgets/selfie-start.*
-  :alt: The Selfie form widget, as displayed in the ODK Collect app on an Android phone. The question text is, "Selfie widget." The hint text is, "image type with selfie appearance." There is a single button, labeled "Take Picture." Above the question text is the form group name "Image widgets."
-
-.. image:: /img/form-widgets/selfie-in-progress.*
-  :alt: A camera view on an Android phone. A person is taking a self-portrait.
-
-.. image:: /img/form-widgets/selfie-complete.*
-  :alt: The Selfie form widget as displayed previously. Below the button is the self-portrait from the previous image.
-
+  
+.. image:: /img/form-question-types/self-portrait-0.* 
+ :alt: The self portrait widget in Collect. The label text is "Self portrait (selfie) widget)". The hint text is "Image type with new-front appearance". There is a button labeled "Take Picture".
+ 
+.. image:: /img/form-question-types/self-portrait-1.* 
+ :alt: The camera screen on a device, taking a self-portrait of a person.
+ 
+.. image:: /img/form-question-types/self-portrait-2.* 
+ :alt: The self portrait widget as described above. Below the button is the self-portrait image captured in the previous image.  
+  
+  
 .. rubric:: XLSForm
 
 .. csv-table:: survey
-  :header: type, name, label, appearance, hint
+  :header: type, name, label, hint, appearance
 
-  image,selfie_image_widget,Selfie widget,new-front,image type with new-front appearance
+  image, self-portrait, Self portrait (*selfie*) widget, image type with new-front appearance, new-front
+  
 
 
 .. _draw-widget:

--- a/odk1-src/img/form-question-types/self-portrait-0.png
+++ b/odk1-src/img/form-question-types/self-portrait-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08abc2af3d4298d952e2b727caf289a59d4721a45d0eea9119844d301ef191ed
+size 51668

--- a/odk1-src/img/form-question-types/self-portrait-1.png
+++ b/odk1-src/img/form-question-types/self-portrait-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d9f35dbf30be00f81ea9f8a4815c5803f646d74708239b379e148d7e62e0751
+size 42045

--- a/odk1-src/img/form-question-types/self-portrait-2.png
+++ b/odk1-src/img/form-question-types/self-portrait-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:950c74464a503b1a256d0b023438368e9af4c1a6af5970d24fa00aef88944664
+size 68859

--- a/odk1-src/img/form-widgets/selfie-complete.png
+++ b/odk1-src/img/form-widgets/selfie-complete.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d415eca8eb21b95ae4ff5cf2b981680104cb01485e7771aeddd6d31d4866b88b
-size 140871

--- a/odk1-src/img/form-widgets/selfie-complete.png
+++ b/odk1-src/img/form-widgets/selfie-complete.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:27991ab9dedd412f792f459a836d8d9c8ad46a5babb0c500929b253666ea9a0e
-size 75221
+oid sha256:d415eca8eb21b95ae4ff5cf2b981680104cb01485e7771aeddd6d31d4866b88b
+size 140871

--- a/odk1-src/img/form-widgets/selfie-in-progress.png
+++ b/odk1-src/img/form-widgets/selfie-in-progress.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ef382623a3777f0da0b136668602c14b65c473483de948f684337e54899cd437
-size 19427

--- a/odk1-src/img/form-widgets/selfie-start.png
+++ b/odk1-src/img/form-widgets/selfie-start.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ffa941a62e5818eab50f160b5443c85f875933aada42fbf4fc298ad50eaa2fb1
-size 54260
+oid sha256:95f0959f692ab3c286596b845bf2375ed7eae99814ccbaa4e8ed78bba76cd376
+size 116514

--- a/odk1-src/img/form-widgets/selfie-start.png
+++ b/odk1-src/img/form-widgets/selfie-start.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:95f0959f692ab3c286596b845bf2375ed7eae99814ccbaa4e8ed78bba76cd376
-size 116514


### PR DESCRIPTION
closes #723 

#### What is included in this PR?

Updates the selfie widget section to use the new-front appearance.

#### Collect 1.15

This PR should not be merged until v.1.15 is released.