### PR TITLE
adds warning to file upload widget

### DIFF
--- a/odk1-src/form-question-types.rst
+++ b/odk1-src/form-question-types.rst
@@ -1527,6 +1527,24 @@ File upload widget
 
 Uploads any file from the device to the form.
 
+.. warning::
+
+  Users can upload **any** file type,
+  which includes potentially malicious files.
+  You should not include this widget
+  unless you trust the people using the form.
+  
+  Even then, you should take precautions 
+  before downloading or opening files.
+  
+  - Run an antimalware scan.
+  - Verify the file is a type you expect 
+    (such as a :file:`.pdf` document),
+    and not a `potentially dangerous file`_
+    (such as :file:`.exe` or :file:`.ini`).
+    
+  .. _potentially dangerous file: https://support.symantec.com/en_US/article.INFO3768.html
+
 .. image:: /img/form-question-types/file-upload-widget.* 
   :alt: The file upload widget in Collect.
        The question label is "Select a file to upload."

--- a/shared-src/spelling_wordlist.txt
+++ b/shared-src/spelling_wordlist.txt
@@ -3,6 +3,8 @@ accessor
 Admin
 admin
 anonymousUser
+antimalware
+antivirus
 apk
 app
 App


### PR DESCRIPTION
closes #667 

#### What is included in this PR?

 - Warning on file upload widget.
 - Added "antimalware"  and "antivirus" to spelling list. (I only used "antimalware" in the new text, actually).

in re:

 - antimalware instead of antivirus
 - antimalware instead of anti-malware

cf: https://docs.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/a/antimalware
