### PR TITLE
Adds section about empty number values

### DIFF
--- a/odk1-src/form-logic.rst
+++ b/odk1-src/form-logic.rst
@@ -188,19 +188,23 @@ That is, they have no value.
 When a :ref:`variable <variables>` referencing an empty value is used 
 in a math :ref:`operator <math-operators>` 
 or :ref:`function <math-functions>`,
-it is treated as Not a Number (NaN).
+it is treated as Not a Number (``NaN``).
 The empty value **will not** be converted to zero.
-The result of a calculation including NaN 
-will also be NaN, 
+The result of a calculation including ``NaN`` 
+will also be ``NaN``, 
 which may not be the behavior you want or expect.
 
 To convert empty values to zero,
-use the :func:`coalesce` function.
+use either the :func:`coalesce` function
+or the :func:`if` function.
 
 .. code-block:: none
 
   coalesce(${potentially_empty_value}, 0)
 
+.. code-block:: none
+
+  if(${potentially_empty_value}="", 0, ${potentially_empty_value})
   
 .. _requiring-responses:
 

--- a/odk1-src/form-logic.rst
+++ b/odk1-src/form-logic.rst
@@ -136,11 +136,15 @@ you must first use a :tc:`calculate` row and then a variable.
   | Tip (18%): $${tip_18}
   | Total: $${tip_18_total}",
 
+.. _form-logic-gotchas:
+
+Form logic gotchas
+-------------------  
 
 .. _when-expressions-are-evaluated:
 
 When expressions are evaluated
---------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Every expression is constantly re-evaluated as an enumerator progresses through a form. This is an important mental model to have and can explain sometimes unexpected behavior. More specifically, expressions are re-evaluated when:
 
@@ -174,6 +178,30 @@ The following calculate will keep track of the first time the enumerator set a v
   calculate, age_timestamp, , "if(age = '', '', once(now()))"
 
 
+.. _empty-values:
+  
+Empty values in math
+~~~~~~~~~~~~~~~~~~~~~
+
+Unanswered :ref:`number questions <number-widgets>` are nil.
+That is, they have no value.
+When a :ref:`variable <variables>` referencing an empty value is used 
+in a math :ref:`operator <math-operators>` 
+or :ref:`function <math-functions>`,
+it is treated as Not a Number (NaN).
+The empty value **will not** be converted to zero.
+The result of a calculation including NaN 
+will also be NaN, 
+which may not be the behavior you want or expect.
+
+To convert empty values to zero,
+use the :func:`coalesce` function.
+
+.. code-block:: none
+
+  coalesce(${potentially_empty_value}, 0)
+
+  
 .. _requiring-responses:
 
 Requiring responses
@@ -492,7 +520,7 @@ Controlling the number of repetitions
 .. _user-controlled-repeats:
     
 User-controlled repeats
-""""""""""""""""""""""""""
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default,
 the user controls how many times 
@@ -530,7 +558,7 @@ the user is asked if they want to add another repeat group.
 .. _statically-defined-repeats:
 
 Statically defined repeats
-----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use the :th:`repeat_count` column
 to define the number of times a group will repeat.
@@ -551,7 +579,7 @@ to define the number of times a group will repeat.
 .. _dynamically-defined-repeats:
  
 Dynamically defined repeats
-""""""""""""""""""""""""""""
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The :th:`repeat_count` column can reference
 :ref:`previous responses <variables>` and :ref:`calculations <calculations>`.

--- a/odk1-src/form-operators-functions.rst
+++ b/odk1-src/form-operators-functions.rst
@@ -50,16 +50,26 @@ Math operators
 ---------------
 
 .. csv-table::
-  :header: , Explanation, Example, Notes
+  :header: , Explanation, Example
   
-  \+, addition, ${salary_income} + ${self_employed_income}, Numbers only; does not concatenate strings.
-  \-, subtraction, ${income} - ${expenses},
-  \*, multiplication, ${bill} * 1.18,
-  div, division, ${percent_int} div 100, 
-  mod, `modulo`_ (division remainder), (${even_number} mod 2) = 0, 
+  \+, addition, ${salary_income} + ${self_employed_income}
+  \-, subtraction, ${income} - ${expenses}
+  \*, multiplication, ${bill} * 1.18
+  div, division, ${percent_int} div 100 
+  mod, `modulo`_ (division remainder), (${even_number} mod 2) = 0
 
 .. _modulo: https://en.wikipedia.org/wiki/Modulo_operation
 
+.. warning::
+
+  Math operators only work with numbers.
+  
+  - The addition operator cannot be used to concatenate strings.
+    Use the :func:`concat` function instead.
+  - Empty values 
+    (that is, :ref:`variables <variables>` referencing unanswered questions)
+    are actually empty strings, 
+    :ref:`and will not be automatically converted to zero (0) <empty-values>`.
   
 .. _comparison-operators:
   
@@ -78,6 +88,13 @@ The result of a comparison is always ``True`` or ``False``.
   >=, greater than or equal to, ${age} >= 18,
   <, less than, ${age} < 65, 
   <=, less than or equal to, ${age} <= 64,
+  
+.. warning::
+
+  - The relational operators (``>``, ``>=``, ``<``, ``<=``)
+    only work with numbers.
+  - :ref:`Empty response values 
+    are not automatically converted to zero (0) <empty-values>`.
   
 .. _boolean-operators:
   
@@ -413,6 +430,16 @@ Repeat groups
       end_repeat
       calculate, age_of_youngest_child, , min(${child_age}) 
 
+      
+.. warning::
+
+  The :func:`min` and :func:`max` functions
+  only work sets of numbers.
+  Empty values 
+  (that is, :ref:`variables <variables>` referencing unanswered questions)
+  are actually empty strings, 
+  :ref:`and will not be automatically converted to zero (0) <empty-values>`.
+       
 .. _string-functions:
   
 Strings
@@ -489,6 +516,18 @@ Converting to and from strings
 Math 
 ------
 
+.. warning::
+
+  Math functions (except :func:`number`) only work with number values.
+  
+  You can use :func:`number` to convert a string of digits to a number,
+  but it is usually better to :ref:`get a number value directly <number-widgets>`.
+  
+  Empty values 
+  (that is, :ref:`variables <variables>` referencing unanswered questions)
+  are actually empty strings, 
+  :ref:`and will not be automatically converted to zero (0) <empty-values>`.
+  
 .. _number-functions:
 
 Number handling

--- a/shared-src/spelling_wordlist.txt
+++ b/shared-src/spelling_wordlist.txt
@@ -131,6 +131,7 @@ Nafundi
 namespace
 namespaced
 namespaces
+NaN
 Oauth
 OAuth
 oauth


### PR DESCRIPTION
closes #731 

#### What is included in this PR?

 - add a "gotcha" subsection to Form Logic building blocks
 - demote "when expressions are evaluated" to subsection of gotcha
 - add section on nil values to form logic gotchas
 - fix some incorrect section header underlining in that file
 - add NaN to spelling list

#### What problems did you encounter?

There's no obviously good place to put this info. @lognaturel suggested a warning in the math operators section, but it applies to math functions and potentially comparisons as well. 

What I came up with makes sense to me, but if anyone disagrees I am open to other ideas.