### PR TITLE
link update

### DIFF
--- a/odk2-src/services-install.rst
+++ b/odk2-src/services-install.rst
@@ -23,7 +23,7 @@ Installing Services
     - (On older versions of Android, this setting is in :menuselection:`Applications` rather than :menuselection:`Security`)
 
   2. Open a web browser on your phone.
-  3. Navigate to http://opendatakit-dev.cs.washington.edu/2_0_tools/download and download the latest ODK Services APK.
+  3. Navigate to http://opendatakit.org/software/odk2/ and download the latest ODK Services APK.
   4. In the download window, you will see ODK_Services_vN.N.N.apk. - Select it to download the file.
 
    - On older devices, the APK will automatically install after you approve the security settings.
@@ -31,7 +31,7 @@ Installing Services
 
 .. note::
 
-  You can also `download the ODK Services APK <https://opendatakit-dev.cs.washington.edu/2_0_tools/download/>`_ to your computer and load it on your device via `adb <https://developer.android.com/studio/command-line/adb.html>`_ or another tool like `AirDroid <https://www.howtogeek.com/105813/control-your-android-from-a-browser-with-airdroid/>`_.
+  You can also `download the ODK Services APK <http://opendatakit.org/software/odk2/>`_ to your computer and load it on your device via `adb <https://developer.android.com/studio/command-line/adb.html>`_ or another tool like `AirDroid <https://www.howtogeek.com/105813/control-your-android-from-a-browser-with-airdroid/>`_.
 
 .. tip::
 

--- a/odk2-src/services-install.rst
+++ b/odk2-src/services-install.rst
@@ -23,7 +23,7 @@ Installing Services
     - (On older versions of Android, this setting is in :menuselection:`Applications` rather than :menuselection:`Security`)
 
   2. Open a web browser on your phone.
-  3. Navigate to http://opendatakit.org/software/odk2/ and download the latest ODK Services APK.
+  3. Navigate to https://github.com/opendatakit/services/releases/latest and download the latest ODK Services APK.
   4. In the download window, you will see ODK_Services_vN.N.N.apk. - Select it to download the file.
 
    - On older devices, the APK will automatically install after you approve the security settings.
@@ -31,7 +31,7 @@ Installing Services
 
 .. note::
 
-  You can also `download the ODK Services APK <http://opendatakit.org/software/odk2/>`_ to your computer and load it on your device via `adb <https://developer.android.com/studio/command-line/adb.html>`_ or another tool like `AirDroid <https://www.howtogeek.com/105813/control-your-android-from-a-browser-with-airdroid/>`_.
+  You can also `download the ODK Services APK <https://github.com/opendatakit/services/releases/latest/>`_ to your computer and load it on your device via `adb <https://developer.android.com/studio/command-line/adb.html>`_ or another tool like `AirDroid <https://www.howtogeek.com/105813/control-your-android-from-a-browser-with-airdroid/>`_.
 
 .. tip::
 


### PR DESCRIPTION
previous link goes to a partially broken page with no apparent way to download

not sure if link should be updated to http://opendatakit.org/software/odk2/ (currently in this PR) or straight to https://github.com/opendatakit/services/releases (which you end up clicking through to from the former link) or something else?