### PR TITLE
Clarify that the picker can be dragged or tapped

### DIFF
--- a/odk1-src/form-question-types.rst
+++ b/odk1-src/form-question-types.rst
@@ -1751,7 +1751,7 @@ type
 type
   :tc:`picker`
   
-When the :tc:`picker` appearance is added, the range widget is displayed with a spinner-style select menu in a dialog. The value between horizontal lines is the selected value. Users can drag the spinner up and down or can tap on the value above to go up by one and on the value below to go down by one.
+When the :tc:`picker` appearance is added, the range widget is displayed with a spinner-style select menu in a dialog. The value between horizontal lines is the selected value. Users can scroll the spinner up and down or can tap on the value above to go up by one and on the value below to go down by one.
 
 .. image:: /img/form-widgets/range-widget-picker-0.* 
   :alt: The range picker widget, as displayed in the ODK Collect app. The question label is "Range picker integer widget". There is a button labeled "Select Value".

--- a/odk1-src/form-question-types.rst
+++ b/odk1-src/form-question-types.rst
@@ -1751,9 +1751,7 @@ type
 type
   :tc:`picker`
   
-When the :tc:`picker` appearance is added,
-the range widget is displayed 
-with a spinner-style select menu in a modal pop up.
+When the :tc:`picker` appearance is added, the range widget is displayed with a spinner-style select menu in a dialog. The value between horizontal lines is the selected value. Users can drag the spinner up and down or can tap on the value above to go up by one and on the value below to go down by one.
 
 .. image:: /img/form-widgets/range-widget-picker-0.* 
   :alt: The range picker widget, as displayed in the ODK Collect app. The question label is "Range picker integer widget". There is a button labeled "Select Value".


### PR DESCRIPTION
It's not immediately obvious that the picker can be tapped to change the value in discrete increments of 1. This can be very useful when counting things as described in https://forum.opendatakit.org/t/dark-theme-radio-buttons-hard-to-see/13499/9?u=ln