### PR TITLE
Move PDF to after building docs, fix case sensitivity, use Docker ima…

### DIFF
--- a/shared-src/docs-tech-guide.rst
+++ b/shared-src/docs-tech-guide.rst
@@ -819,49 +819,6 @@ to get any help about style guide testing:
 
   $ python style-test.py -h
 
-.. _docs-pdf:
-
-Building PDF for docs
-~~~~~~~~~~~~~~~~~~~~~~
-
-The docs can be downloaded as PDF for the ease of users.
-
-To build the pdf locally, follow these steps:
-
-.. note::
-
-  All steps below explain the build process for odk1-docs. To build pdf for odk2-docs in a similar way, you can replace **1** with **2** in the above commands.
-
-1. Install XeLatex
-
-  .. code-block:: console
-
-    $ sudo apt-get install texlive-xetex
-
-  For MacOS, refer `mactex <https://www.tug.org/mactex/>`_.
-  For Windows, refer `miktex <https://miktex.org/>`_.
-
-  .. note::
-
-    A docker image for XeLatex can be used as well instead of installing it on your system. Some of the useful links for the same:
-
-      - https://github.com/moss-it/docker-xelatex
-      - https://github.com/thomasWeise/docker-texlive
-
-2. Build latex for ODK docs
-
-  .. code-block:: console
-
-    $ make odk1-latex
-
-3. Generate pdf for the produced tex file
-
-  .. code-block:: console
-
-    $ make odk1-pdf
-
-  The pdf will be generated in :file:`/odk1-build/_downloads/ODK-Documentation.pdf`
-
 .. _build-the-docs:
 
 Build, View, and Debug
@@ -936,6 +893,45 @@ It's a good idea to delete the ``build`` directory before each rebuild.
   In the future, 
   it will also become the canonical build script for ODK Docs,
   including additional tests and other build tasks.
+
+.. _build-pdf:
+
+Build the Docs as a PDF
+~~~~~~~~~~~~~~~~~~~~~~~
+
+To build the docs as a PDF, follow these steps:
+
+.. note::
+
+  The steps below explain the build process for ODK 1's docs. To build the PDF for ODK 2's docs, replace **1** with **2** in the below commands.
+
+1. Install XeLatex
+
+  - For macOS, use `MacTex <https://www.tug.org/mactex/>`_.
+  - For Windows, use `MiKTeX <https://miktex.org/>`_.
+  - For Ubuntu (or Debian), run
+
+    .. code-block:: console
+
+      $ sudo apt-get install texlive-xetex
+
+  .. note::
+
+    Instead of installing XeLatex directly on your system, you can also use this `Docker image <https://github.com/schickling/dockerfiles/tree/master/latex>`_.
+
+2. Build LaTex file
+
+  .. code-block:: console
+
+    $ make odk1-latex
+
+3. Generate PDF for the produced LaTex file
+
+  .. code-block:: console
+
+    $ make odk1-pdf
+
+  The PDF will be generated in :file:`/odk1-build/_downloads/ODK-Documentation.pdf`
 
 .. _push-the-docs:
 

--- a/shared-src/spelling_wordlist.txt
+++ b/shared-src/spelling_wordlist.txt
@@ -44,6 +44,7 @@ datastores
 datatype
 datatypes
 datestamp
+Debian
 deviceID
 docutils
 Docutils
@@ -156,6 +157,7 @@ orderBy
 passcode
 passphrase
 pdf
+PDF
 permissioning
 plaintext
 plugins
@@ -214,7 +216,6 @@ submissionList
 SVG
 svg
 templating
-tex
 toolbar
 toolchain
 trackpad


### PR DESCRIPTION
Addresses #784 

#### What is included in this PR?
Couple of changes to tighten the prose...
* I moved the PDF to after building the docs. Feels like a better place.
* I made sure we are using the correct case for all the things (e.g., MacTex instead of mactex).
* I used the Docker image we use in CircleCI so we know it works.

#### What is left to be done in the addressed issue?
https://github.com/opendatakit/docs/pull/788 has to be merged before the `make odk1-pdf` works.
