### PR TITLE
Describe rank widget

### DIFF
--- a/odk1-src/form-question-types.rst
+++ b/odk1-src/form-question-types.rst
@@ -1054,6 +1054,45 @@ you can add :tc:`or_other`.
 This will add "Other" as an additional option to your choice list.
 The :th:`name` value of the choice when selected will be :tc:`other`.
 
+
+.. _rank-widget:
+
+Rank widget
+-----------------
+
+The rank widget allows the user to order options from a list. The value saved in the form and sent to the server is a space-separated ordered list of the options.
+
+Like with :ref:`select-widgets`, the options are listed on a sheet named **choices** in an XLSForm.
+
+To change the order of the options in the list, tap the "Rank items" button. In the resulting dialog, long press on items and once they get a border around them, drag them up or down to change their order. If no :ref:`default <default-responses>` is provided, the value for the question is blank until the user taps "OK" in the ranking dialog.
+
+type
+  :tc:`rank {list_name}`
+
+.. image:: /img/form-widgets/rank-blank.*
+  :alt: The rank widget, as displayed in the ODK Collect app on an Android phone. The question text is "Rank widget." The hint text is "rank type with no appearance, 4 text choices. Long press on a choice and drag it to change its position." Below that is a button with label "Rank items."
+
+.. image:: /img/form-widgets/rank-drag.*
+  :alt: The rank widget, as displayed in the ODK Collect app on an Android phone. The question text is "Rank widget." The hint text is "rank type with no appearance, 4 text choices. Long press on a choice and drag it to change its position." A dialog is open showing the options to rank. The B option has a border around it and is being moved into position 4.
+
+.. image:: /img/form-widgets/rank-ordered.*
+ :alt: The rank widget, as displayed in the ODK Collect app on an Android phone. The question text is "Rank widget." The hint text is "rank type with no appearance, 4 text choices. Long press on a choice and drag it to change its position." Below that is a button with label "Rank items." Below the button is the current order of the options.
+
+.. rubric:: XLSForm
+
+.. csv-table:: survey
+  :header: type, name, label, hint
+
+  rank opt_abcd,rank_widget,Rank widget,"rank type with no appearance, 4 text choices"
+
+.. csv-table:: choices
+  :header: list_name, name, label
+
+  opt_abcd,a,A
+  opt_abcd,b,B
+  opt_abcd,c,C
+  opt_abcd,d,D
+
   
 .. _location-widgets:
 

--- a/odk1-src/form-question-types.rst
+++ b/odk1-src/form-question-types.rst
@@ -1064,7 +1064,7 @@ The rank widget allows the user to order options from a list. The value saved in
 
 Like with :ref:`select-widgets`, the options are listed on a sheet named **choices** in an XLSForm.
 
-To change the order of the options in the list, tap the "Rank items" button. In the resulting dialog, long press on items and once they get a border around them, drag them up or down to change their order. If no :ref:`default <default-responses>` is provided, the value for the question is blank until the user taps "OK" in the ranking dialog.
+To change the order of the options in the list, tap the :guilabel:`Rank items` button. In the resulting dialog, long press on an item and once it gets a border around it, drag it up or down to change the order. If no :ref:`default <default-responses>` is provided, the value for the question is blank until the user taps :guilabel:`OK` in the ranking dialog.
 
 type
   :tc:`rank {list_name}`

--- a/odk1-src/img/form-widgets/rank-blank.png
+++ b/odk1-src/img/form-widgets/rank-blank.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed79697962fcb9680de0a597229ef2f6b5bbfee7c3320072b5ea17ce4f4d4186
+size 59869

--- a/odk1-src/img/form-widgets/rank-drag.png
+++ b/odk1-src/img/form-widgets/rank-drag.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38d60e7af8bbd6b6a259d76a9cc821d40bc0027e44010f74d430b7664ed3df45
+size 63350

--- a/odk1-src/img/form-widgets/rank-ordered.png
+++ b/odk1-src/img/form-widgets/rank-ordered.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e66df045e0e301cc48ded3f7c663a83cba79cd68f85d45b0ead036f413260f9c
+size 65075


### PR DESCRIPTION
Closes #747 

Describes the rank widget usage, shows its XLSForm usage and adds 3 screenshots of a rank question with a blank value, an active ranking and a rank question with a set value.

Verified by running locally, clicking on all links introduced and running `make odk1-check`.