### PR TITLE
Removed link to /use which is redirected to docs

### DIFF
--- a/shared-src/docs-style-guide.rst
+++ b/shared-src/docs-style-guide.rst
@@ -1036,7 +1036,7 @@ XLSForm
 
 - The `XLSForm format for describing form in an Excel spreadsheet <http://xlsform.org/>`_
 - A spreadsheet file that describes a form using the format.
-- An `online tool <http://opendatakit.org/use/xlsform/>`_ and an `offline tool <https://gumroad.com/l/xlsform-offline>`_ for converting :file:`*.xls(x)` files to XForm documents. 
+- An `online tool <https://docs.opendatakit.org/xlsform/>`_ and an `offline tool <https://gumroad.com/l/xlsform-offline>`_ for converting :file:`*.xls(x)` files to XForm documents. 
 
 When writing about any of these things, make sure you are clear --- in your mind as well as in your writing --- which one you are talking about.
 


### PR DESCRIPTION
Related issue: https://github.com/opendatakit/docs/issues/261

<!-- ALL PRs MUST BE RELATED TO AN OPEN ISSUE -->
closes #
<!-- OR -->
addresses #


#### What is included in this PR?



<!-- Answer any that apply and delete the others. -->
#### What new issues will need to be opened because of this PR?

#### What is left to be done in the addressed issue?

#### What problems did you encounter?
