### PR TITLE
Update links that are no longer relevant

### DIFF
--- a/odk1-src/aggregate-upgrade.rst
+++ b/odk1-src/aggregate-upgrade.rst
@@ -107,10 +107,10 @@ General steps for upgrading
    from an older one.
    
    Some versions will require manual changes upon upgrade. 
-   Complete notes about upgrading to each version 
-   are available in the `Aggregate release notes`_.
-   
-   .. _Aggregate release notes: https://github.com/opendatakit/opendatakit/wiki/Aggregate-Release-Notes 
+   Complete notes about upgrading can be found in the release notes:
+
+   * `v1.4.15 and earlier <https://github.com/opendatakit/opendatakit/wiki/Aggregate-Release-Notes>`_
+   * `v1.5.0 and later <https://github.com/opendatakit/aggregate/releases>`_
 
 #. Log onto your server to confirm that it is still functioning.
 #. Repeat the steps 4-7 until you have upgraded to the current version.

--- a/odk1-src/collect-install.rst
+++ b/odk1-src/collect-install.rst
@@ -38,5 +38,4 @@ If you need a different version of Collect, you can download from the web and in
 
 .. tip::
 
-  You can also `install ODK Collect on an Android emulator <https://github.com/opendatakit/opendatakit/wiki/DevEnv-Setup>`_. However, this can be slow and is only recommended for developers actively working on Collect.
-
+  You can install ODK Collect on the `Android emulator <https://developer.android.com/studio/run/emulator>`_. This is especially helpful if you need to :doc:`project Collect onto a screen <projecting-collect>`.

--- a/odk1-src/security-privacy.rst
+++ b/odk1-src/security-privacy.rst
@@ -49,7 +49,7 @@ Our user website (`opendatakit <https://opendatakit.org/>`_.org) does not knowin
 
 Our software uses a number of open-source 3rd-party libraries from well-known and/or reputable sources, and a few from obscure sources. We do not vet the security of those software libraries.
 
-Your security people may want to review the libraries and source code on our `source code site <https://github.com/opendatakit/opendatakit/>`_.
+Your security people may want to review the libraries and source code on `GitHub <https://github.com/opendatakit>`_.
 
 .. _odk-aggregate-communications:
 

--- a/shared-src/docs-style-guide.rst
+++ b/shared-src/docs-style-guide.rst
@@ -1036,7 +1036,7 @@ XLSForm
 
 - The `XLSForm format for describing form in an Excel spreadsheet <http://xlsform.org/>`_
 - A spreadsheet file that describes a form using the format.
-- An `online tool <https://docs.opendatakit.org/xlsform/>`_ and an `offline tool <https://gumroad.com/l/xlsform-offline>`_ for converting :file:`*.xls(x)` files to XForm documents. 
+- A :doc:`tool <xlsform>` for converting :file:`*.xls(x)` files to XForm documents.
 
 When writing about any of these things, make sure you are clear --- in your mind as well as in your writing --- which one you are talking about.
 

--- a/shared-src/faq.rst
+++ b/shared-src/faq.rst
@@ -36,7 +36,6 @@ How do I use ODK?
 The following docs will help you learn how to use ODK:
 
   * The `Getting Started Guide <https://docs.opendatakit.org/getting-started/>`_ walks you though the basic setup process.
-  * The `developer wiki <https://github.com/opendatakit/opendatakit/wiki>`_ contains information on how to set up your developer environment.
   * The `ODK forum <https://forum.opendatakit.org/>`_ has community discussions on using ODK.
 
 .. _what-kinds-question:


### PR DESCRIPTION
#### What is included in this PR?
* Release notes are now split between old versions and new versions
* These are user docs, so reference the most likely use of an emulator
* Our source is on GitHub. We can say that more directly
* XLSForm link is local. Also, Gumroad isn't a thing we use anymore
* The developer wiki is out of date and not that useful
