### PR TITLE
Describe how to increase Aggregate db field length beyond 255

### DIFF
--- a/odk1-src/aggregate-deployment-planning.rst
+++ b/odk1-src/aggregate-deployment-planning.rst
@@ -78,6 +78,10 @@ the :ref:`data export feature <export-data>` will stop working. To correct this,
 
 On Google App Engine, a larger server will incur higher billing costs. Additionally, for datasets of over 100,000 records, it is likely that performance will be better when using MySQL or PostgreSQL, rather than Google App Engine's data store. You also have more optimization opportunities when running your own database servers than are available through Google's cloud services.
 
+.. note::
+
+  Individual text database fields are capped at a length of 255 by default for performance reasons. If you intend to collect text data longer than 255 characters (including using types :ref:`geotrace <geotrace-widget>`, :ref:`geoshape <geoshape-widget>` or :ref:`select multiple <multi-select-widget>`), your forms should :doc:`specify database field lengths greater than 255 <aggregate-field-length>`.
+
 .. _aggregate-deployment-data-locality:
 
 Data locality and security

--- a/odk1-src/aggregate-field-length.rst
+++ b/odk1-src/aggregate-field-length.rst
@@ -1,0 +1,27 @@
+.. spelling::
+
+  abc
+
+Increasing Aggregate Field Length
+====================================
+
+By default, Aggregate's datastore layer limits text values to 255 characters or less. If a submission includes a value longer than 255 characters, those additional characters **are not saved in the database** and no warning is shown. That means there is a risk of data loss when using question types that save long text values such as :ref:`geotrace <geotrace-widget>`, :ref:`geoshape <geoshape-widget>` or :ref:`select multiple <multi-select-widget>`. This limitation exists for performance reasons, particularly for older versions of MySQL.
+
+It is possible to set the desired database field length for a particular question. This value can go up to about 16000 UTF-8 characters but the datastore storage efficiency may get worse as the value increases.
+
+In an XLSForm, the database field length is set from the ``bind::odk:length`` column. On form upload, Aggregate will adjust the database field length of questions that have a whole number in that column. Other questions will get a default length of 255.
+
+.. rubric:: XLSForm
+
+.. csv-table:: survey
+  :header: type, name, label, bind::odk:length
+
+  select_multiple opt_abc, multi, Select multi, 500
+  geoshape, shape, Select an area, 1000
+
+.. csv-table:: choices
+  :header: list_name, name, label
+
+  opt_abc, a, A
+  opt_abc, b, B
+  opt_abc, c, C

--- a/odk1-src/form-best-practices.rst
+++ b/odk1-src/form-best-practices.rst
@@ -6,3 +6,4 @@ Tips and Best Practices
   form-repeats
   form-regex
   form-update
+  aggregate-field-length

--- a/odk1-src/form-question-types.rst
+++ b/odk1-src/form-question-types.rst
@@ -70,6 +70,10 @@ Text widgets
 All of the text widgets share the :tc:`text` type,
 and the inputs from them are saved as literal strings.
 
+.. warning::
+
+  If you are using Aggregate and expect answers to be more than 255 characters, you should :doc:`increase the database field length to over 255 characters <aggregate-field-length>`.
+
 .. contents::
  :local:
 
@@ -941,6 +945,10 @@ Multi select questions support multiple answers.
   opt_abcd,c,C
   opt_abcd,d,D
 
+.. warning::
+
+  If you are using Aggregate and expect users to select many options, you may need to :doc:`increase the database field length to over 255 characters <aggregate-field-length>`.
+
      
 .. _image-map-select:
   
@@ -1292,6 +1300,10 @@ Automatic Mode
   :header: type, name, label
 
   geotrace, trace_example, Where have you been?
+
+.. warning::
+
+  If you are using Aggregate and you would like to collect more than 5 points at a time, you should :doc:`increase the database field length to over 255 characters <aggregate-field-length>`. Otherwise, additional points will be lost.
   
   
 .. _geoshape-widget:
@@ -1327,6 +1339,10 @@ Captures a user-entered series of location coordinates, forming a polygon.
   :header: type, name, label
 
   geoshape, shape_example, Select an area
+
+.. warning::
+
+  If you are using Aggregate and you would like to collect more than 5 points at a time, you should :doc:`increase the database field length to over 255 characters <aggregate-field-length>`. Otherwise, additional points will be lost.
 
 .. _geoshape-area:
     


### PR DESCRIPTION
<!-- ALL PRs MUST BE RELATED TO AN OPEN ISSUE -->
closes #745
<!-- OR -->
addresses #


#### What is included in this PR?

Description of why there's a 255 char limit on Aggregate db text fields. Instructions on increasing that value on specific questions in XLSForm. Warnings in places users are likely to hit this limitation.