### PR TITLE
media in question prompt clarifications

### DIFF
--- a/odk1-src/form-language.rst
+++ b/odk1-src/form-language.rst
@@ -42,10 +42,6 @@ For example:
 
 .. note::
 
-  All columns that can be made multi-lingual, need to be created as such for a multi-language form. For example, even if using the same image for a question prompt you will need a :th:`media::image::*` column for each language. However, you may provide the same media filename for each.
-
-.. note::
-
   The text shown in Collect's user interface (e.g., buttons, menus, dialogs)
   is controlled by device language, not the form language.
   If you would like Collect's user interface to support your language,
@@ -106,6 +102,11 @@ For example:
   the non-specific version of that column
   will be treated as if it were a separate language.
   (The :menuselection:`Change Language` menu will list it as :guilabel:`Default`.)
+  
+  To avoid this, all columns that can be made multi-lingual, need to be created 
+  as such for a multi-language form. For example, even if using the same image 
+  for a question prompt you will need a :th:`media::image::*` column for each 
+  language. However, you may provide the same media filename for each.
 
   Blank cells in a language-specific column
   will be blank in the form when that language is active,

--- a/odk1-src/form-language.rst
+++ b/odk1-src/form-language.rst
@@ -38,6 +38,11 @@ For example:
 
 - :th:`label::English (en)`
 - :th:`hint::French (fr)`
+- :th:`media::image::Español (es)`
+
+.. note::
+
+  All columns that can be made multi-lingual, need to be created as such for a multi-language form. For example, even if using the same image for a question prompt you will need a :th:`media::image::*` column for each language. However, you may provide the same media filename for each.
 
 .. note::
 

--- a/odk1-src/form-language.rst
+++ b/odk1-src/form-language.rst
@@ -112,6 +112,13 @@ For example:
   will be blank in the form when that language is active,
   even if the "default" column has a value.
 
+.. rubric:: XLSForm --- Multiple languages with media example
+
+.. csv-table:: survey
+  :header: type, name, label::English (en), label::Español (es), media::image::Español (es), media::image::English (en)
+  
+  text, coffee, Do you want coffee?, ¿Quieres café?, mug_es.jpg, mug_en.jpg
+  
     
 .. _switching-languages:
   

--- a/odk1-src/form-language.rst
+++ b/odk1-src/form-language.rst
@@ -103,7 +103,7 @@ For example:
   will be treated as if it were a separate language.
   (The :menuselection:`Change Language` menu will list it as :guilabel:`Default`.)
   
-  To avoid this, all columns that can be made multi-lingual, need to be created 
+  To avoid this, all columns that can be made multi-lingual need to be created 
   as such for a multi-language form. For example, even if using the same image 
   for a question prompt you will need a :th:`media::image::*` column for each 
   language. However, you may provide the same media filename for each.

--- a/odk1-src/form-language.rst
+++ b/odk1-src/form-language.rst
@@ -5,6 +5,7 @@
   Español
   Púrpura
   Qué
+  Quieres
   Rojo
   Seleccione
   colores

--- a/odk1-src/form-styling.rst
+++ b/odk1-src/form-styling.rst
@@ -292,9 +292,9 @@ You can include questions in your form that display images or that play video or
 .. rubric:: XLSForm
 
 .. csv-table:: survey
-  :header: type, name, label
+  :header: type, name, label, media::image
   
-  select_one yesnodk, coffee, Do you want coffee?
+  select_one yesnodk, coffee, Do you want coffee?, mug.jpg 
   
 .. csv-table:: choices
   :header: list_name, name, label

--- a/odk1-src/form-styling.rst
+++ b/odk1-src/form-styling.rst
@@ -15,9 +15,34 @@
 Form Styling
 ==============
 
-Labels, hints, and choices in an :doc:`xlsform`
+Questions can include :ref:`media` such as images, sound or video. 
+Additionally, labels, hints, and choices in an :doc:`xlsform`
 can all be styled using 
 :ref:`markdown-in-forms`, :ref:`fonts and colors <custom-fonts-colors>`, and :ref:`emoji`.
+
+.. _media:
+
+Media
+------
+
+You can include questions in your form that display images or that play video or audio files by including a :th:`media` column in your `XLSForm <http://xlsform.org/#media>`_.
+
+.. image:: /img/form-styling/media-image.* 
+  :alt: A single select widget in Collect. The label text is "Do you want coffee?" The label text is accompanied by a picture of a mug of coffee. The options are "yes", "no", and "I don't know".
+
+.. rubric:: XLSForm
+
+.. csv-table:: survey
+  :header: type, name, label, media::image
+  
+  select_one yesnodk, coffee, Do you want coffee?, mug.jpg 
+  
+.. csv-table:: choices
+  :header: list_name, name, label
+  
+  yesnodk, y, yes
+  yesnodk, n, no
+  yesnodk, dk, I don't know
 
 
 .. _markdown-in-forms:
@@ -283,27 +308,6 @@ Emoji can be used in form labels, hints, and answer choices.
   pain, 7, 😱
 
   
-Media
-------
-
-You can include questions in your form that display images or that play video or audio files by including a :th:`media` column in your `XLSForm <http://xlsform.org/#media>`_.
-
-.. image:: /img/form-styling/media-image.* 
-  :alt: A single select widget in Collect. The label text is "Do you want coffee?" The label text is accompanied by a picture of a mug of coffee. The options are "yes", "no", and "I don't know".
-
-.. rubric:: XLSForm
-
-.. csv-table:: survey
-  :header: type, name, label, media::image
-  
-  select_one yesnodk, coffee, Do you want coffee?, mug.jpg 
-  
-.. csv-table:: choices
-  :header: list_name, name, label
-  
-  yesnodk, y, yes
-  yesnodk, n, no
-  yesnodk, dk, I don't know
 
 ------
 

--- a/odk1-src/form-styling.rst
+++ b/odk1-src/form-styling.rst
@@ -283,6 +283,28 @@ Emoji can be used in form labels, hints, and answer choices.
   
 ------
 
+Media
+------
+
+You can include questions in your form that display images or that play video or audio files by including a :th:`media` column in your `XLSForm <http://xlsform.org/#media>`_.
+
+.. image:: /img/form-styling/media-image.* 
+  :alt: A single select widget in Collect. The label text is "Do you want coffee?" The label text is accompanied by a picture of a mug of coffee. The options are "yes", "no", and "I don't know".
+
+.. rubric:: XLSForm
+
+.. csv-table:: survey
+  :header: type, name, label
+  
+  select_one yesnodk, coffee, Do you want coffee?
+  
+.. csv-table:: choices
+  :header: list_name, name, label
+  
+  yesnodk, y, yes
+  yesnodk, n, no
+  yesnodk, dk, I don't know
+
 .. seealso:: 
   
   - `Styling prompts in XLSForm <http://xlsform.org/#styling>`_

--- a/odk1-src/form-styling.rst
+++ b/odk1-src/form-styling.rst
@@ -281,8 +281,6 @@ Emoji can be used in form labels, hints, and answer choices.
   pain, 7, 😱
 
   
-------
-
 Media
 ------
 
@@ -304,6 +302,8 @@ You can include questions in your form that display images or that play video or
   yesnodk, y, yes
   yesnodk, n, no
   yesnodk, dk, I don't know
+
+------
 
 .. seealso:: 
   

--- a/odk1-src/form-styling.rst
+++ b/odk1-src/form-styling.rst
@@ -3,11 +3,13 @@
   CSS
   Emoji
   bolding
+  dk
   emoji
   md
   monospace
   supertext
   tt
+  yesnodk
   yn
 	
 Form Styling

--- a/odk1-src/img/form-styling/media-image.png
+++ b/odk1-src/img/form-styling/media-image.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cdc20784f6364f0b8f930370754b5d92bd3b8c80aa7981a1a7f73fb655f0d373
+size 569264

--- a/shared-src/spelling_wordlist.txt
+++ b/shared-src/spelling_wordlist.txt
@@ -46,7 +46,6 @@ datatypes
 datestamp
 Debian
 deviceID
-dk
 docutils
 Docutils
 downloadable
@@ -276,5 +275,4 @@ XLSForm
 xml
 xmlns
 XPath
-yesnodk
 zeroes

--- a/shared-src/spelling_wordlist.txt
+++ b/shared-src/spelling_wordlist.txt
@@ -46,6 +46,7 @@ datatypes
 datestamp
 Debian
 deviceID
+dk
 docutils
 Docutils
 downloadable
@@ -275,4 +276,5 @@ XLSForm
 xml
 xmlns
 XPath
+yesnodk
 zeroes


### PR DESCRIPTION
looks to resolve #749

#### What is included in this PR?

- Adds some more detail to the form-language section to try and avoid issues when using a media column in a multi-lingual form.
- Adds a section on media to form-styling per suggestion from @adammichaelwood in issue thread.

#### What is left to be done in the addressed issue?
- I didn't see any flags from the spelling and style checks that were a result of my edits.
- Get feedback on if wording changes/additions help clarify or just reduce brevity without helping improve docs.
- Get feedback if adding a media section to form-styling is the right move.

#### What problems did you encounter?
- I had trouble getting the `style-test.py` to run on just the diff or a specified file. I could get `python style-test.py -r odk1-src` to run on all the docs but didn't figure out the additional parameters.
- Took me a second to realize that `sphinx-build -b spelling src build/spelling` needed to be run as `sphinx-build -b spelling odk1-src build/spelling`.