### PR TITLE
Lossless image compression of media-image.png

### DIFF
--- a/odk1-src/img/form-styling/media-image.png
+++ b/odk1-src/img/form-styling/media-image.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cdc20784f6364f0b8f930370754b5d92bd3b8c80aa7981a1a7f73fb655f0d373
-size 569264
+oid sha256:be024a4db474ef99bd2fddda917bb2e375a7dddcd4636a4095c9882a547add81
+size 490274


### PR DESCRIPTION
Addresses #836 

#### What is included in this PR?
Ran the image through ImageOptim to shrink it. It's still much larger than most of our other images, but I think that's due to the fact that it has a hard to compress section (e.g., the coffee cup)