### PR TITLE
Google writes App Engine with space

### DIFF
--- a/odk1-src/aggregate-admin.rst
+++ b/odk1-src/aggregate-admin.rst
@@ -70,7 +70,7 @@ In the :guilabel:`Preferences` sub-tab under :guilabel:`Site Admin` tab, you can
 
 - **Aggregate features**: These settings affect the operations of the server.
    
-   - *Disable faster background actions* - check this to reduce AppEngine quota usage.
+   - *Disable faster background actions* - check this to reduce App Engine quota usage.
    - *Skip malformed submissions* - check this to ignore corrupted submissions.
 
 .. image:: /img/aggregate-use/preferences-options.*

--- a/odk1-src/aggregate-boost-performance.rst
+++ b/odk1-src/aggregate-boost-performance.rst
@@ -54,7 +54,7 @@ To change the Google App Engine web server size:
  
    To change the size of the web server, replace **F2** with a different instance class size. 
    
-   There are several different instance classes available. Select from among the instance classes beginning with the letter **F**. See `instance classes <https://cloud.google.com/appengine/docs/about-the-standard-environment#instance_classes>`_  for their descriptions or search for `Google AppEngine instance classes standard environment` on the web. 
+   There are several different instance classes available. Select from among the instance classes beginning with the letter **F**. See `instance classes <https://cloud.google.com/appengine/docs/about-the-standard-environment#instance_classes>`_  for their descriptions or search for `Google App Engine instance classes standard environment` on the web. 
    
 4. Re-run the upload tool within the ODKAggregate folder.
 

--- a/odk1-src/aggregate-limitations.rst
+++ b/odk1-src/aggregate-limitations.rst
@@ -22,7 +22,7 @@ The 60-second request limit can be very commonly exceeded over low-bandwidth con
 
 .. note::
    
-   - The above two limitations, the global mutex and the in-memory copies/full-packet-assembly, are a result of implementing on top of AppEngine and its Datastore.
+   - The above two limitations, the global mutex and the in-memory copies/full-packet-assembly, are a result of implementing on top of App Engine and its Datastore.
    - A server that used database transactions and that used streaming servlet 3.0 functionality would have less trouble with concurrent requests.
 
 Media held in memory
@@ -32,7 +32,7 @@ When a form submission is uploaded, and when blank forms are downloaded, all the
 
 The previous section already suggested serializing form submission uploads. This is not absolutely critical for form downloads, but you should probably manage how many form download requests are being handled concurrently, in order to avoid memory problems.
 
-..  Spinning up of copies of the frontend will incur faster quota usage on AppEngine. For that reason, the Aggregate configuration here specifies a 14-second queuing time threshold before a new instance is spun up. Only if at least one request is queued for longer than 14 seconds will a new instance be spun up, and then that new instance will take about 30 seconds to become live. Leaving a 15-second processing interval. This is why ODK Collect tried twice before failing a submit.
+..  Spinning up of copies of the frontend will incur faster quota usage on App Engine. For that reason, the Aggregate configuration here specifies a 14-second queuing time threshold before a new instance is spun up. Only if at least one request is queued for longer than 14 seconds will a new instance be spun up, and then that new instance will take about 30 seconds to become live. Leaving a 15-second processing interval. This is why ODK Collect tried twice before failing a submit.
 
 Uploading blank forms with media exceeding 10MB
 -------------------------------------------------

--- a/odk1-src/aggregate-upgrade.rst
+++ b/odk1-src/aggregate-upgrade.rst
@@ -39,7 +39,7 @@ Hosting revisions
 
 If you are using Google App Engine as we recommend, your hosting environment is being continuously updated.
 
-Google AppEngine is a managed environment, unlike AWS or other "bare-box" hosting services. Google is continuously updating features and removing support for older features in this environment. 
+Google App Engine is a managed environment, unlike AWS or other "bare-box" hosting services. Google is continuously updating features and removing support for older features in this environment.
 
 The Aggregate development team is committed to supporting Google App Engine, so we update our application as the platform changes. If you do not upgrade gradually as new versions come out, your installation may stop working or cease to have a viable upgrade path.
 

--- a/odk1-src/openrosa-form-submission.rst
+++ b/odk1-src/openrosa-form-submission.rst
@@ -42,7 +42,7 @@ Successful server responses MUST include an ``X-OpenRosa-Accept-Content-Length``
 Servers SHOULD include this header in their error responses. However, clients MUST NOT rely on the presence of this header (or any OpenRosa header) in every error response.
 
 .. note:: 
-  Overly-large requests sent to Google AppEngine will be rejected prior to being sent to any server, and will therefore not contain this (or any) OpenRosa header.
+  Overly-large requests sent to Google App Engine will be rejected prior to being sent to any server, and will therefore not contain this (or any) OpenRosa header.
   
 OpenRosa submissions are POSTed to servers as a multipart MIME Envelope with at least 1 part --- the XML content of the form itself. Each of these parts should adhere to the following requirements
 

--- a/odk2-src/odk-2-sync-protocol.rst
+++ b/odk2-src/odk-2-sync-protocol.rst
@@ -91,7 +91,7 @@ Requests should specify 3 or 4 headers:
 
   - **X-OpenDataKit-Version** -- this should be set to `2.0`
   - **X-OpenDataKit-Installation-Id** -- this should be set to a UUID that identifies this client device. This UUID will generally be generated on first install of the ODK Services APK. Using "Clear Data" in the device settings will cause a new UUID to be generated. This is used to track the devices responsible for changes to the configuration (resetting the server) and for tracking the status of all devices as they synchronize with the server.
-  - **User-Agent** -- this is required by Google AppEngine infrastructure before it will honor requests for GZIP content compression of response entities (i.e., it ignores "Accept-Encoding" directives on requests if this is not present). The value supplied must end with " (gzip)". Services uses a value of: `"Sync " + versionCode + " (gzip)"` where `versionCode` is is the revision code of the software release (e.g., 210). While optional, it is highly recommended that all requests supply this header.
+  - **User-Agent** -- this is required by Google App Engine infrastructure before it will honor requests for GZIP content compression of response entities (i.e., it ignores "Accept-Encoding" directives on requests if this is not present). The value supplied must end with " (gzip)". Services uses a value of: `"Sync " + versionCode + " (gzip)"` where `versionCode` is is the revision code of the software release (e.g., 210). While optional, it is highly recommended that all requests supply this header.
   - **Accept-Encoding** -- this should be set to "gzip" when an entity body is returned.
 
 .. _sync-protocol-rest-data-structures:


### PR DESCRIPTION
#### What is included in this PR?
Minor copy edit to fix AppEngine when used in text. See https://cloud.google.com/appengine for proof that the spelling requires a space.