### PR TITLE
Update security privacy

### DIFF
--- a/odk1-src/security-privacy.rst
+++ b/odk1-src/security-privacy.rst
@@ -36,7 +36,7 @@ All our installers, programs, source code, and documentation are provided AS-IS 
 Communication Channels
 ---------------------------
 
-None of the downloadable ODK software transmits or communicates any information back to us and the software we have written does not have any mechanisms that might allow us to access or control your devices or systems.
+Outside of usage analytics and crash reports, ODK software does not transmit or communicate any information back to ODK's maintainers. Further, the software we have written does not have any mechanisms that might allow us to access or control your devices or systems.
 
 There is always the possibility that hackers can discover and exploit deficiencies or bugs in our software or in 3rd-party libraries to access or control your devices or systems.
 
@@ -127,30 +127,37 @@ During data submission, some identifying information is transmitted and stored o
 
 While interacting with an :ref:`ODK Aggregate <aggregate-introduction>` website, any actions that require authentication and that modify the server settings, set of form definitions, filters, exports, publishers, or data tables, will cause the authenticated username or Google account to be written into the audit fields of the database tables that are being updated. If these modifications result in delete actions being performed against a database table, then this authenticated username or Google account will be identified in the server log together with summary information on what was deleted.
 
-.. _security-privacy-odk-collect:
+.. _security-privacy-odk-briefcase:
 
-ODK Collect
+ODK Briefcase
 -------------
 
-We gather anonymous aggregate user behavior through Google Analytics. We use secure HTTPS communication to transfer this data off the device and the data are available to ODK's maintainers. Users may disable analytics in the settings of :ref:`ODK Collect <collect-introduction>`.
+We gather anonymous aggregate user behavior through Google Analytics and gather anonymous crash logs through Sentry. We use secure HTTPS communication to transfer this data to ODK's maintainers. Users may disable analytics in the settings of the application. Crash logging cannot be disabled.
 
 .. _security-privacy-odk-build:
 
 ODK Build
----------------
+---------
 
-We require secure HTTPS connections to ODK Build. We gather anonymous aggregate user behavior through Google Analytics. We use secure HTTPS communication to transfer this data and the data are available to ODK's maintainers.
+We require secure HTTPS connections to ODK Build. We gather anonymous aggregate user behavior through Google Analytics. We use secure HTTPS communication to transfer this data to ODK's maintainers.
+
+.. _security-privacy-odk-collect:
+
+ODK Collect
+-----------
+
+We gather anonymous aggregate user behavior through Google Analytics and gather anonymous crash logs through Google Firebase Crashlytics. We use secure HTTPS communication to transfer this data to ODK's maintainers. Users may disable analytics in the settings of the application. Crash logging cannot be disabled.
 
 .. _security-privacy-xlsform-online:
 
 XLSForm Online
--------------------------
+--------------
 
-ref:`XLSForm Online <xlsform-introduction>` does not use a secure connection. This means that your form definition files (both XLS and XML) are visible to a determined observer when submitted and downloaded from that site, as are any reported errors in the form.
+We require secure HTTPS connections to XLSForm Online. We gather anonymous aggregate user behavior through Google Analytics. We use secure HTTPS communication to transfer this data to ODK's maintainers.
 
-Furthermore, XLSForm Online stores both your submitted XLS and the generated XML form for a period of time on its disk drive before being deleted (this is necessary for the operation of the tool).
+XLSForm Online stores both your submitted XLS and the generated XML form for a period of time on its disk drive before being deleted (this is necessary for the operation of the tool).
 
-XLSForm Offline and ODK Validate, because they operate locally without any network communications, provide a secure alternative to the convenience of this online tool.
+XLSForm Offline operates locally without any network communications and provides a secure alternative to the convenience of this online tool.
 
 .. _security-privacy-odk-websites:
 

--- a/odk1-src/security-privacy.rst
+++ b/odk1-src/security-privacy.rst
@@ -51,6 +51,54 @@ Our software uses a number of open-source 3rd-party libraries from well-known an
 
 Your security people may want to review the libraries and source code on `GitHub <https://github.com/opendatakit>`_.
 
+.. _security-privacy-odk-briefcase:
+
+ODK Briefcase
+-------------
+
+We gather anonymous aggregate user behavior through Google Analytics and gather anonymous crash logs through Sentry. We use secure HTTPS communication to transfer this data to ODK's maintainers. Users may disable analytics in the settings of the application. Crash logging cannot be disabled.
+
+.. _security-privacy-odk-build:
+
+ODK Build
+---------
+
+We require secure HTTPS connections to ODK Build. We gather anonymous aggregate user behavior through Google Analytics. We use secure HTTPS communication to transfer this data to ODK's maintainers.
+
+.. _security-privacy-odk-collect:
+
+ODK Collect
+-----------
+
+We gather anonymous aggregate user behavior through Google Analytics and gather anonymous crash logs through Google Firebase Crashlytics. We use secure HTTPS communication to transfer this data to ODK's maintainers. Users may disable analytics in the settings of the application. Crash logging cannot be disabled.
+
+.. _security-privacy-xlsform-online:
+
+XLSForm Online
+--------------
+
+We require secure HTTPS connections to XLSForm Online. We gather anonymous aggregate user behavior through Google Analytics. We use secure HTTPS communication to transfer this data to ODK's maintainers.
+
+XLSForm Online stores both your submitted XLS and the generated XML form for a period of time on its disk drive before being deleted (this is necessary for the operation of the tool).
+
+XLSForm Offline operates locally without any network communications and provides a secure alternative to the convenience of this online tool.
+
+.. _security-privacy-odk-websites:
+
+Websites
+-------------
+
+Our websites under the opendatakit.org domain can or do use cookies and can or do log all interactions. We also utilize security software, spam-blocking, and web-analytics tools (for example, Google Web Analytics) that may track visitors and their access patterns on our web properties.
+
+.. _security-privacy-google-play-store:
+
+Google Play Store
+-----------------------
+
+Downloads from the Google Play store are compiled into aggregated usage statistics on our management portal.
+
+Crash reports you elect to send are provided to us as anonymous crash reports. By design, these do not contain survey field values or other device- or user- specific data.
+
 .. _odk-aggregate-communications:
 
 ODK Aggregate Communications
@@ -127,53 +175,6 @@ During data submission, some identifying information is transmitted and stored o
 
 While interacting with an :ref:`ODK Aggregate <aggregate-introduction>` website, any actions that require authentication and that modify the server settings, set of form definitions, filters, exports, publishers, or data tables, will cause the authenticated username or Google account to be written into the audit fields of the database tables that are being updated. If these modifications result in delete actions being performed against a database table, then this authenticated username or Google account will be identified in the server log together with summary information on what was deleted.
 
-.. _security-privacy-odk-briefcase:
-
-ODK Briefcase
--------------
-
-We gather anonymous aggregate user behavior through Google Analytics and gather anonymous crash logs through Sentry. We use secure HTTPS communication to transfer this data to ODK's maintainers. Users may disable analytics in the settings of the application. Crash logging cannot be disabled.
-
-.. _security-privacy-odk-build:
-
-ODK Build
----------
-
-We require secure HTTPS connections to ODK Build. We gather anonymous aggregate user behavior through Google Analytics. We use secure HTTPS communication to transfer this data to ODK's maintainers.
-
-.. _security-privacy-odk-collect:
-
-ODK Collect
------------
-
-We gather anonymous aggregate user behavior through Google Analytics and gather anonymous crash logs through Google Firebase Crashlytics. We use secure HTTPS communication to transfer this data to ODK's maintainers. Users may disable analytics in the settings of the application. Crash logging cannot be disabled.
-
-.. _security-privacy-xlsform-online:
-
-XLSForm Online
---------------
-
-We require secure HTTPS connections to XLSForm Online. We gather anonymous aggregate user behavior through Google Analytics. We use secure HTTPS communication to transfer this data to ODK's maintainers.
-
-XLSForm Online stores both your submitted XLS and the generated XML form for a period of time on its disk drive before being deleted (this is necessary for the operation of the tool).
-
-XLSForm Offline operates locally without any network communications and provides a secure alternative to the convenience of this online tool.
-
-.. _security-privacy-odk-websites:
-
-Websites
--------------
-
-Our websites under the opendatakit.org domain can or do use cookies and can or do log all interactions. We also utilize security software, spam-blocking, and web-analytics tools (for example, Google Web Analytics) that may track visitors and their access patterns on our web properties.
-
-.. _security-privacy-google-play-store:
-
-Google Play Store
------------------------
-
-Downloads from the Google Play store are compiled into aggregated usage statistics on our management portal.
-
-Crash reports you elect to send are provided to us as anonymous crash reports. By design, these do not contain survey field values or other device- or user- specific data.
 
 ----
 

--- a/odk1-src/security-privacy.rst
+++ b/odk1-src/security-privacy.rst
@@ -19,7 +19,7 @@ This document details known security and privacy considerations of the ODK softw
 .. _license:
 
 License 
------------
+-------
 
 The ODK software is released under the `Apache 2 License`_.
 
@@ -34,22 +34,83 @@ All our installers, programs, source code, and documentation are provided AS-IS 
 .. _communication-channels:
 
 Communication Channels
----------------------------
+----------------------
 
-Outside of usage analytics and crash reports, ODK software does not transmit or communicate any information back to ODK's maintainers. Further, the software we have written does not have any mechanisms that might allow us to access or control your devices or systems.
+Outside of usage analytics (typically opt-out) and crash reports (typically required), ODK software does not transmit or communicate any information back to ODK's maintainers. Further, the software we have written does not have any mechanisms that might allow us to access or control your devices or systems.
 
 There is always the possibility that hackers can discover and exploit deficiencies or bugs in our software or in 3rd-party libraries to access or control your devices or systems.
-
-Our user website (`opendatakit <https://opendatakit.org/>`_.org) does not knowingly contain 3rd party ads and does not collect personally identifiable information from the general public.
 
 .. _3rd-party-software:
 
 3rd-party Software
-----------------------
+------------------
 
 Our software uses a number of open-source 3rd-party libraries from well-known and/or reputable sources, and a few from obscure sources. We do not vet the security of those software libraries.
 
 Your security people may want to review the libraries and source code on `GitHub <https://github.com/opendatakit>`_.
+
+.. _security-privacy-odk-websites:
+
+Websites
+--------
+
+Our websites under the opendatakit.org domain can or do use cookies and can or do log all interactions. We also utilize security software, spam-blocking, and web-analytics tools (for example, Google Web Analytics) that may track visitors and their access patterns on our web properties.
+
+.. _security-privacy-google-play-store:
+
+Google Play Store
+-----------------------
+
+Downloads from the Google Play Store are compiled into aggregated usage statistics.
+
+Crash reports you elect to send are provided to us as anonymous crash reports. By design, these do not contain survey field values or other device- or user- specific data.
+
+.. _security-privacy-odk-aggregate:
+
+ODK Aggregate
+--------------
+
+.. _odk-aggregate-communications:
+
+Communications
+~~~~~~~~~~~~~~
+
+When setting up your own webserver to run :ref:`ODK Aggregate <aggregate-introduction>`, if you do not configure the server and :ref:`ODK Aggregate <aggregate-introduction>` to use an SSL certificate, a determined observer can see all data communicated to and from that server.
+
+Only transmissions over an https:// connection are obscured from observers.
+
+The definition of an encrypted form (:ref:`check here <encrypted-forms>`) is transmitted in plaintext (unencrypted) to the device. When a filled-in submission for an encrypted form is finalized, it is encrypted on the device and transmitted in encrypted form. While this may meet requirements for obscured transmission over unsecured http:// connections, unsecured connections still allow observers to alter the form definition to potentially remove the encryption, capture any filled-in forms, or potentially intercept and thereby prevent their transmission to your server.
+
+.. _odk-aggregate-deployments:
+
+Deployments to Google App Engine or Other Hosting Services
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+With all 3rd party hosting services, you should expect your data to be viewable by the support staff of the hosting service. Different services go to differing lengths to restrict access to, encrypt, and/or secure the data and communications within their data centers.
+
+The form definition and associated media files of an encrypted form (:ref:`ODK see here <encrypted-forms>`) are stored on the server in plaintext (unencrypted). When a filled-in submission for an encrypted form is finalized, it is encrypted on the device and transmitted to the server in encrypted form, where it is stored. The secret key required for decryption is not stored on the server, thereby preventing anyone at the hosting service from seeing your filled-in form data and attachments unless they break the encryption.
+
+See :doc:`aggregate-deployment-planning` for other considerations.
+
+.. _odk-aggregate-username-authentication:
+
+Username Authentication
+~~~~~~~~~~~~~~~~~~~~~~~
+
+When authenticating :ref:`ODK Aggregate <aggregate-introduction>` usernames and passwords, the ODK tools use DigestAuth. This enables secure username/password authentication even while communicating with servers over http:// (when using DigestAuth, the password is not sent over the network).
+
+An encoded form of the username's password is stored on the server. If that encoded value is stolen or revealed, it can allow others to log in and interact with the server as that user.
+
+.. _google-account-authentication:
+
+Google Account Authentication
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For authentication of Google accounts (Gmail or Google Apps), :ref:`ODK Aggregate <aggregate-introduction>` accepts OAuth2 tokens with rights to view a user's email address (just the address --- not the email or user profile) as proof-of-identity.
+
+**This is a very weak proof-of-identity.** Every time you authorize Google to share your email address with other sites or applications, those sites or applications have the permissions necessary to act on your behalf on :ref:`ODK Aggregate <aggregate-introduction>` (should they want to).
+
+For this reason, it may be inappropriate to declare and grant Google email addresses access to your site. This access is required for ODK 2.0 Sync functionality at rev 128 and earlier.
 
 .. _security-privacy-odk-briefcase:
 
@@ -83,48 +144,14 @@ XLSForm Online stores both your submitted XLS and the generated XML form for a p
 
 XLSForm Offline operates locally without any network communications and provides a secure alternative to the convenience of this online tool.
 
-.. _security-privacy-odk-websites:
 
-Websites
--------------
-
-Our websites under the opendatakit.org domain can or do use cookies and can or do log all interactions. We also utilize security software, spam-blocking, and web-analytics tools (for example, Google Web Analytics) that may track visitors and their access patterns on our web properties.
-
-.. _security-privacy-google-play-store:
-
-Google Play Store
------------------------
-
-Downloads from the Google Play store are compiled into aggregated usage statistics on our management portal.
-
-Crash reports you elect to send are provided to us as anonymous crash reports. By design, these do not contain survey field values or other device- or user- specific data.
-
-.. _odk-aggregate-communications:
-
-ODK Aggregate Communications
----------------------------------
-
-When setting up your own webserver to run :ref:`ODK Aggregate <aggregate-introduction>`, if you do not configure the server and :ref:`ODK Aggregate <aggregate-introduction>` to use an SSL certificate, a determined observer can see all data communicated to and from that server.
-
-Only transmissions over an https:// connection are obscured from observers.
-
-The definition of an encrypted form (:ref:`check here <encrypted-forms>`) is transmitted in plaintext (unencrypted) to the device. When a filled-in submission for an encrypted form is finalized, it is encrypted on the device and transmitted in encrypted form. While this may meet requirements for obscured transmission over unsecured http:// connections, unsecured connections still allow observers to alter the form definition to potentially remove the encryption, capture any filled-in forms, or potentially intercept and thereby prevent their transmission to your server.
-
-.. _odk-aggregate-deployments:
-
-ODK Aggregate Deployments to Google App Engine or Other Hosting Services
--------------------------------------------------------------------------
-
-With all 3rd party hosting services, you should expect your data to be viewable by the support staff of the hosting service. Different services go to differing lengths to restrict access to, encrypt, and/or secure the data and communications within their data centers.
-
-The form definition and associated media files of an encrypted form (:ref:`ODK see here <encrypted-forms>`) are stored on the server in plaintext (unencrypted). When a filled-in submission for an encrypted form is finalized, it is encrypted on the device and transmitted to the server in encrypted form, where it is stored. The secret key required for decryption is not stored on the server, thereby preventing anyone at the hosting service from seeing your filled-in form data and attachments unless they break the encryption.
-
-See :doc:`aggregate-deployment-planning` for other considerations.
+Cross-tool Concerns
+-------------------
 
 .. _encrypted-form-security:
 
 Encrypted Form Security
----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~
 
 The form definition and associated media files of an :ref:`ODK encrypted form <encrypted-forms>` are stored on the server in plaintext (unencrypted). And are transmitted and stored on the devices in plaintext.
 
@@ -142,30 +169,10 @@ On the server, if an observer were able to access your encrypted data, since eac
 
 Currently, cracking AES encryption is viewed as impossible for all but the most advanced governmental agencies (for example, the NSA).
 
-.. _odk-aggregate-username-authentication:
-
-ODK Aggregate Username Authentication
---------------------------------------
-
-When authenticating :ref:`ODK Aggregate <aggregate-introduction>` usernames and passwords, the ODK tools use DigestAuth. This enables secure username/password authentication even while communicating with servers over http:// (when using DigestAuth, the password is not sent over the network).
-
-An encoded form of the username's password is stored on the server. If that encoded value is stolen or revealed, it can allow others to log in and interact with the server as that user.
-
-.. _google-account-authentication:
-
-Google Account Authentication
--------------------------------
-
-For authentication of Google accounts (Gmail or Google Apps), :ref:`ODK Aggregate <aggregate-introduction>` accepts OAuth2 tokens with rights to view a user's email address (just the address --- not the email or user profile) as proof-of-identity.
-
-**This is a very weak proof-of-identity.** Every time you authorize Google to share your email address with other sites or applications, those sites or applications have the permissions necessary to act on your behalf on :ref:`ODK Aggregate <aggregate-introduction>` (should they want to).
-
-For this reason, it may be inappropriate to declare and grant Google email addresses access to your site. This access is required for ODK 2.0 Sync functionality at rev 128 and earlier.
-
 .. _identifying-information-transmission-storage:
 
 Identifying Information Transmission and Storage
---------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 During data submission, some identifying information is transmitted and stored on the server:
 
@@ -174,7 +181,6 @@ During data submission, some identifying information is transmitted and stored o
   - If :ref:`ODK Aggregate <aggregate-introduction>` is configured to require authentication (username / password or Google account) for submission (that is, if the Data Collector permission is NOT granted to the anonymousUser), then the username (or Google account) that authenticated is written into the audit fields of the data tables storing the submission. If the anonymousUser is granted Data Collector privileges, no authentication is performed, and ``anonymousUser`` is written into those fields. The content of these audit fields is not exposed in exported CSV files, ODK Briefcase data pulls, or published to downstream systems. However, because it is present in the database tables, you can definitely correlate this authenticated username or Google account with the submitted data.
 
 While interacting with an :ref:`ODK Aggregate <aggregate-introduction>` website, any actions that require authentication and that modify the server settings, set of form definitions, filters, exports, publishers, or data tables, will cause the authenticated username or Google account to be written into the audit fields of the database tables that are being updated. If these modifications result in delete actions being performed against a database table, then this authenticated username or Google account will be identified in the server log together with summary information on what was deleted.
-
 
 ----
 

--- a/odk1-src/security-privacy.rst
+++ b/odk1-src/security-privacy.rst
@@ -1,5 +1,7 @@
 .. spelling::
 
+  Crashlytics
+  Firebase
   Gejibo
   Hussien
   imei
@@ -36,7 +38,9 @@ All our installers, programs, source code, and documentation are provided AS-IS 
 Communication Channels
 ----------------------
 
-Outside of usage analytics (typically opt-out) and crash reports (typically required), ODK software does not transmit or communicate any information back to ODK's maintainers. Further, the software we have written does not have any mechanisms that might allow us to access or control your devices or systems.
+Outside of anonymous usage analytics (typically opt-out) and anonymous crash reports (typically required), ODK software does not transmit or communicate any information (e.g., survey data) back to ODK's maintainers.
+
+The software we have written does not have any mechanisms that might allow us to access or control your devices or systems.
 
 There is always the possibility that hackers can discover and exploit deficiencies or bugs in our software or in 3rd-party libraries to access or control your devices or systems.
 
@@ -47,14 +51,14 @@ There is always the possibility that hackers can discover and exploit deficienci
 
 Our software uses a number of open-source 3rd-party libraries from well-known and/or reputable sources, and a few from obscure sources. We do not vet the security of those software libraries.
 
-Your security people may want to review the libraries and source code on `GitHub <https://github.com/opendatakit>`_.
+Your security staff may want to review the libraries and source code on `GitHub <https://github.com/opendatakit>`_.
 
 .. _security-privacy-odk-websites:
 
 Websites
 --------
 
-Our websites under the opendatakit.org domain can or do use cookies and can or do log all interactions. We also utilize security software, spam-blocking, and web-analytics tools (for example, Google Web Analytics) that may track visitors and their access patterns on our web properties.
+Our websites under the opendatakit.org domain use cookies and log all interactions. We also web analytics tools (for example, Google Analytics) that may track visitors and their access patterns on our web properties.
 
 .. _security-privacy-google-play-store:
 
@@ -63,7 +67,7 @@ Google Play Store
 
 Downloads from the Google Play Store are compiled into aggregated usage statistics.
 
-Crash reports you elect to send are provided to us as anonymous crash reports. By design, these do not contain survey field values or other device- or user- specific data.
+Crash reports you elect to send are provided to us as anonymous crash reports. By design, these do not contain device or user specific data.
 
 .. _security-privacy-odk-aggregate:
 
@@ -75,20 +79,20 @@ ODK Aggregate
 Communications
 ~~~~~~~~~~~~~~
 
-When setting up your own webserver to run :ref:`ODK Aggregate <aggregate-introduction>`, if you do not configure the server and :ref:`ODK Aggregate <aggregate-introduction>` to use an SSL certificate, a determined observer can see all data communicated to and from that server.
+When setting up your own web server to run ODK Aggregate, if you do not configure the server and ODK Aggregate to use an SSL certificate, a determined observer can see all data communicated to and from that server.
 
-Only transmissions over an https:// connection are obscured from observers.
+:ref:`encrypted-form-security` can prevent a determined observer from viewing encrypted form data being sent via insecure HTTP, but it cannot prevent the observer from silently removing encryption from form definitions and capturing any unencrypted form data that is then submitted.
 
-The definition of an encrypted form (:ref:`check here <encrypted-forms>`) is transmitted in plaintext (unencrypted) to the device. When a filled-in submission for an encrypted form is finalized, it is encrypted on the device and transmitted in encrypted form. While this may meet requirements for obscured transmission over unsecured http:// connections, unsecured connections still allow observers to alter the form definition to potentially remove the encryption, capture any filled-in forms, or potentially intercept and thereby prevent their transmission to your server.
+Only transmissions over a secure HTTPS connection are obscured from observers and prevent tampering in transmission.
 
 .. _odk-aggregate-deployments:
 
-Deployments to Google App Engine or Other Hosting Services
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Google App Engine and other Hosting Services
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 With all 3rd party hosting services, you should expect your data to be viewable by the support staff of the hosting service. Different services go to differing lengths to restrict access to, encrypt, and/or secure the data and communications within their data centers.
 
-The form definition and associated media files of an encrypted form (:ref:`ODK see here <encrypted-forms>`) are stored on the server in plaintext (unencrypted). When a filled-in submission for an encrypted form is finalized, it is encrypted on the device and transmitted to the server in encrypted form, where it is stored. The secret key required for decryption is not stored on the server, thereby preventing anyone at the hosting service from seeing your filled-in form data and attachments unless they break the encryption.
+:ref:`encrypted-form-security` can prevent hosting services from viewing encrypted form data at rest, but cannot prevent the hosted service from silently removing encryption from form definitions and viewing any unencrypted form data that is then submitted.
 
 See :doc:`aggregate-deployment-planning` for other considerations.
 
@@ -97,20 +101,9 @@ See :doc:`aggregate-deployment-planning` for other considerations.
 Username Authentication
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-When authenticating :ref:`ODK Aggregate <aggregate-introduction>` usernames and passwords, the ODK tools use DigestAuth. This enables secure username/password authentication even while communicating with servers over http:// (when using DigestAuth, the password is not sent over the network).
+When authenticating ODK Aggregate usernames and passwords, the ODK tools use DigestAuth. This enables secure username/password authentication even while communicating with servers over HTTP. When using DigestAuth, the password is not sent over the network.
 
 An encoded form of the username's password is stored on the server. If that encoded value is stolen or revealed, it can allow others to log in and interact with the server as that user.
-
-.. _google-account-authentication:
-
-Google Account Authentication
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-For authentication of Google accounts (Gmail or Google Apps), :ref:`ODK Aggregate <aggregate-introduction>` accepts OAuth2 tokens with rights to view a user's email address (just the address --- not the email or user profile) as proof-of-identity.
-
-**This is a very weak proof-of-identity.** Every time you authorize Google to share your email address with other sites or applications, those sites or applications have the permissions necessary to act on your behalf on :ref:`ODK Aggregate <aggregate-introduction>` (should they want to).
-
-For this reason, it may be inappropriate to declare and grant Google email addresses access to your site. This access is required for ODK 2.0 Sync functionality at rev 128 and earlier.
 
 .. _security-privacy-odk-briefcase:
 
@@ -140,9 +133,9 @@ XLSForm Online
 
 We require secure HTTPS connections to XLSForm Online. We gather anonymous aggregate user behavior through Google Analytics. We use secure HTTPS communication to transfer this data to ODK's maintainers.
 
-XLSForm Online stores both your submitted XLS and the generated XML form for a period of time on its disk drive before being deleted (this is necessary for the operation of the tool).
+XLSForm Online stores both your submitted XLS and the generated XML form for a period of time on its disk drive before being deleted. This is necessary for the operation of the tool.
 
-XLSForm Offline operates locally without any network communications and provides a secure alternative to the convenience of this online tool.
+XLSForm Offline operates locally without any network communications and provides a secure alternative to the convenience of XLSForm Online.
 
 
 Cross-tool Concerns
@@ -153,19 +146,21 @@ Cross-tool Concerns
 Encrypted Form Security
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-The form definition and associated media files of an :ref:`ODK encrypted form <encrypted-forms>` are stored on the server in plaintext (unencrypted). And are transmitted and stored on the devices in plaintext.
+The form definition and associated media files of an :ref:`ODK encrypted form <encrypted-forms>` are stored on the server in plaintext (unencrypted). The form definition and media files are transmitted as plaintext (but perhaps through a secure HTTPS connection) to client devices (e.g., an Android phone running ODK Collect) and stored in plaintext.
 
-Prior to finalizing a filled-in form, all form data and attachments are stored in plaintext (unencrypted) on the device.
+All form data (e.g., incomplete forms, saved forms) and media files are stored in plaintext on the client device until they are finalized. It is only once the form data is finalized that those files are encrypted.
 
-At the time a filled-in form is finalized, a random 256-bit encryption/decryption key is generated for that filled-in form using the SecureRandom number generator (`found here <https://docs.oracle.com/javase/7/docs/api/java/security/SecureRandom.html>`_). This ensures that every filled-in form has its own unique 256-bit encryption/decryption key.
+At the time form data and media attachments are finalized, a random 256-bit encryption/decryption key is generated for that form data using the SecureRandom number generator (`found here <https://docs.oracle.com/javase/7/docs/api/java/security/SecureRandom.html>`_). This ensures that every finalized form has its own unique 256-bit encryption/decryption key.
 
-The filled-in form data and all media attachments are then encrypted with that key using 256-bit AES Cipher Feedback (CFB) streaming-block encryption. Once encrypted, all plaintext files and attachments for that filled-in form are deleted.
+The form data and media attachments are then encrypted with that key using 256-bit AES Cipher Feedback (CFB) streaming-block encryption. Once encrypted, all plaintext form data and attachments that were used in that process are deleted.
 
 The random key is then padded and encrypted using the RSA public key declared in the form definition (recommended to be 2048-bit) and the OAEPWithSHA256AndMGF1Padding algorithm. The resulting encrypted key is transmitted to the server along with the encrypted data and encrypted attachments. This submission includes a signature field that enables the software to detect tampering to any of the encrypted attachments or to the encrypted form data.
 
-On the device, copies of the deleted (plaintext) filled-in form data and attachments may remain in the free-list of the SDCard until they are overwritten with new content.
+On the device, copies of the deleted plaintext form data and attachments may remain in the free-list of the SD card until they are overwritten with new content.
 
-On the server, if an observer were able to access your encrypted data, since each filled-in submission uses a different key, each submission would need to be cracked separately.
+On the server, if an observer were able to access your encrypted form data, since each form submission uses a different key, each submission would need to be cracked separately.
+
+The secret key required for decryption is never stored on the server, thereby preventing anyone from seeing your form data and attachments unless they break the encryption.
 
 Currently, cracking AES encryption is viewed as impossible for all but the most advanced governmental agencies (for example, the NSA).
 
@@ -176,11 +171,11 @@ Identifying Information Transmission and Storage
 
 During data submission, some identifying information is transmitted and stored on the server:
 
-  - :ref:`ODK Collect <collect-introduction>` passes the deviceID of the device to the server during the submission process. (the HEAD request that initiates the submission is a URL of the form: .../submission?deviceID=imei%3A9117DD011813771 ). The :ref:`ODK Aggregate <aggregate-introduction>` server does not store this deviceID in any database tables, but it will generally be emitted into the webserver access log. This deviceID uniquely identifies the device from which the data is submitted. This can be useful when correlating events on the server with interactions from specific devices. Because this is logged, it is likely that a submission can be correlated with a device, and therefore a data collector.
+  - ODK Collect passes the deviceID of the device to the server during the submission process. The HEAD request that initiates the submission is a URL of the form: ``.../submission?deviceID=imei%3A9117DD011813771``. The ODK Aggregate server does not store this deviceID in any database tables, but it will generally be emitted into the webserver access log. This deviceID uniquely identifies the device from which the data is submitted. This can be useful when correlating events on the server with interactions from specific devices. Because this is logged, it is likely that a submission can be correlated with a device, and therefore a data collector.
 
-  - If :ref:`ODK Aggregate <aggregate-introduction>` is configured to require authentication (username / password or Google account) for submission (that is, if the Data Collector permission is NOT granted to the anonymousUser), then the username (or Google account) that authenticated is written into the audit fields of the data tables storing the submission. If the anonymousUser is granted Data Collector privileges, no authentication is performed, and ``anonymousUser`` is written into those fields. The content of these audit fields is not exposed in exported CSV files, ODK Briefcase data pulls, or published to downstream systems. However, because it is present in the database tables, you can definitely correlate this authenticated username or Google account with the submitted data.
+  - If ODK Aggregate is configured to require authentication for submission (that is, if the Data Collector permission is NOT granted to the anonymousUser), then the username that authenticated is written into the audit fields of the data tables storing the submission. If the anonymousUser is granted Data Collector privileges, no authentication is performed, and anonymousUser is written into those fields. The content of these audit fields is not exposed in exported CSV files, ODK Briefcase data pulls, or published to downstream systems. However, because it is present in the database tables, you can definitely correlate this authenticated username with the submitted data.
 
-While interacting with an :ref:`ODK Aggregate <aggregate-introduction>` website, any actions that require authentication and that modify the server settings, set of form definitions, filters, exports, publishers, or data tables, will cause the authenticated username or Google account to be written into the audit fields of the database tables that are being updated. If these modifications result in delete actions being performed against a database table, then this authenticated username or Google account will be identified in the server log together with summary information on what was deleted.
+While interacting with an ODK Aggregate website, any actions that require authentication and that modify the server settings, set of form definitions, filters, exports, publishers, or data tables, will cause the authenticated username to be written into the audit fields of the database tables that are being updated. If these modifications result in delete actions being performed against a database table, then this authenticated username will be identified in the server log together with summary information on what was deleted.
 
 ----
 

--- a/odk1-src/security-privacy.rst
+++ b/odk1-src/security-privacy.rst
@@ -38,7 +38,7 @@ All our installers, programs, source code, and documentation are provided AS-IS 
 Communication Channels
 ----------------------
 
-Outside of anonymous usage analytics (typically opt-out) and anonymous crash reports (typically required), ODK software does not transmit or communicate any information (e.g., survey data) back to ODK's maintainers.
+Outside of usage analytics (typically opt-out) and crash reports (typically required), ODK software does not transmit or communicate any information (e.g., survey data) back to ODK's maintainers. When we do gather data, we default to anonymous or aggregate methods.
 
 The software we have written does not have any mechanisms that might allow us to access or control your devices or systems.
 
@@ -58,7 +58,7 @@ Your security staff may want to review the libraries and source code on `GitHub 
 Websites
 --------
 
-Our websites under the opendatakit.org domain use cookies and log all interactions. We also web analytics tools (for example, Google Analytics) that may track visitors and their access patterns on our web properties.
+Our websites under the opendatakit.org domain use cookies and log all interactions. We also use web analytics tools (for example, Google Analytics) that may track visitors and their access patterns on our web properties.
 
 .. _security-privacy-google-play-store:
 
@@ -67,7 +67,7 @@ Google Play Store
 
 Downloads from the Google Play Store are compiled into aggregated usage statistics.
 
-Crash reports you elect to send are provided to us as anonymous crash reports. By design, these do not contain device or user specific data.
+Crash reports you elect to send are provided to us anonymously. By design, these do not contain device or user specific data.
 
 .. _security-privacy-odk-aggregate:
 
@@ -110,28 +110,28 @@ An encoded form of the username's password is stored on the server. If that enco
 ODK Briefcase
 -------------
 
-We gather anonymous aggregate user behavior through Google Analytics and gather anonymous crash logs through Sentry. We use secure HTTPS communication to transfer this data to ODK's maintainers. Users may disable analytics in the settings of the application. Crash logging cannot be disabled.
+We gather aggregate user behavior through Google Analytics and gather crash logs through Sentry. We use secure HTTPS communication to transfer this data to ODK's maintainers. Users may disable analytics in the settings of the application. Crash logging cannot be disabled.
 
 .. _security-privacy-odk-build:
 
 ODK Build
 ---------
 
-We require secure HTTPS connections to ODK Build. We gather anonymous aggregate user behavior through Google Analytics. We use secure HTTPS communication to transfer this data to ODK's maintainers.
+We require secure HTTPS connections to ODK Build. We gather aggregate user behavior through Google Analytics. We use secure HTTPS communication to transfer this data to ODK's maintainers.
 
 .. _security-privacy-odk-collect:
 
 ODK Collect
 -----------
 
-We gather anonymous aggregate user behavior through Google Analytics and gather anonymous crash logs through Google Firebase Crashlytics. We use secure HTTPS communication to transfer this data to ODK's maintainers. Users may disable analytics in the settings of the application. Crash logging cannot be disabled.
+We gather aggregate user behavior through Google Analytics and gather crash logs through Google Firebase Crashlytics. We use secure HTTPS communication to transfer this data to ODK's maintainers. Users may disable analytics in the settings of the application. Crash logging cannot be disabled.
 
 .. _security-privacy-xlsform-online:
 
 XLSForm Online
 --------------
 
-We require secure HTTPS connections to XLSForm Online. We gather anonymous aggregate user behavior through Google Analytics. We use secure HTTPS communication to transfer this data to ODK's maintainers.
+We require secure HTTPS connections to XLSForm Online. We gather aggregate user behavior through Google Analytics. We use secure HTTPS communication to transfer this data to ODK's maintainers.
 
 XLSForm Online stores both your submitted XLS and the generated XML form for a period of time on its disk drive before being deleted. This is necessary for the operation of the tool.
 


### PR DESCRIPTION
Closes #832 

#### What is included in this PR?
Update to current practice and re-arranging so it's easier to read. The big changes are 
* Combining all the Aggregate things in one section and moving the bits that are focused on encryption into the general encryption section so it's easier to read.
* Dropped the Google Account section because it's no longer relevant for Aggregate.
* Update the rest of the tools language to match current practice
* Creating a new cross-tool concerns section

I think the easiest way to parse these changes is to read the docs at https://docs.opendatakit.org/security-privacy and compare it to what this PR has. 