### PR TITLE
Correct sms submission custom delimiter example

### DIFF
--- a/odk1-src/collect-sms-submissions.rst
+++ b/odk1-src/collect-sms-submissions.rst
@@ -58,7 +58,7 @@ Optionally, a ``prefix`` can be specified for the form to identify submissions f
 
 Additionally, an optional ``delimiter`` can be specified. This value will be included between each prefix, tag and form value. By default, the delimiter is a single space. If you allow spaces in the form values and expect to process your SMS messages by splitting on delimiters, you should set a delimiter other than space. For example, you could use ``+`` for the following result:
 
-``my-form|fn|Sally Sue|ln|David|a|23``
+``my-form+fn+Sally Sue+ln+David+a+23``
 
 .. csv-table:: settings
   :header: prefix, delimiter


### PR DESCRIPTION
I think this corrects the example of an SMS form submission with custom delimiter.  The text implies that fields should be delimited by `+`, but the example shows a `|` (pipe).  Pipe wouldn't be a great delimiter to pick, as it's not included in the [standard GSM SMS character set](https://en.wikipedia.org/wiki/GSM_03.38#GSM_7-bit_default_alphabet_and_extension_table_of_3GPP_TS_23.038_/_GSM_03.38).