### PR TITLE
Change App to app

### DIFF
--- a/odk1-src/getting-started.rst
+++ b/odk1-src/getting-started.rst
@@ -14,7 +14,7 @@ You will:
 Install Collect
 ---------------------
 
-The easiest way to install the Collect App is `to get it from the Google Play store <https://play.google.com/store/apps/details?id=org.odk.collect.android&hl=en>`_.
+The easiest way to install the Collect app is `to get it from the Google Play store <https://play.google.com/store/apps/details?id=org.odk.collect.android&hl=en>`_.
 
 .. seealso:: :doc:`collect-install`
 


### PR DESCRIPTION
<!-- ALL PRs MUST BE RELATED TO AN OPEN ISSUE -->
closes # not applicable

Drops down the "A" in App under **Install Collect** "The easiest way to install the Collect App is to get it from the Google Play store."

No known associated issues as a result of this PR.

This issue is resolved.

No problems encountered.
