### PR TITLE
remove misleading note

### DIFF
--- a/odk1-src/form-operators-functions.rst
+++ b/odk1-src/form-operators-functions.rst
@@ -646,7 +646,7 @@ Converting dates and time
   
 .. function:: decimal-date-time(dateTime)
 
-  Converts :arg:`dateTime` value to the number of days since January 1, 1970 UTC. This is the format used by Excel.
+  Converts :arg:`dateTime` value to the number of days since January 1, 1970 UTC.
   
   This is the inverse of :func:`date`.
 


### PR DESCRIPTION
see the discussion at:
https://forum.opendatakit.org/t/value-produced-by-decimal-date-time/15751

should this edit add the additional detail about "it's the format used by Excel but off by 70 years" instead of just removing the sentence?
