### PR TITLE
Add a more generic warning about the default password

### DIFF
--- a/odk1-src/aggregate-admin.rst
+++ b/odk1-src/aggregate-admin.rst
@@ -12,7 +12,7 @@ Click the :guilabel:`Log In` link in the upper right corner of the screen to be 
    - If the instance name of the server changes (the installer asks for this name), then the passwords for all ODK Aggregate usernames will be cleared (preventing their use) and the super-user username's password will be reset to aggregate and the above message will also be displayed. In this case, you should log in, change the super-user's password, and change the passwords for all of your ODK Aggregate usernames.
    - In April 2015, the use of Google e-mail accounts for accessing the site (via Sign in with Google) stopped working (Google turned off that functionality).  If you have an existing site running an old version of ODK Aggregate that does not have ODK Aggregate usernames configured for website access (and offers a Sign in with Google sign-in choice), you will need to upgrade to regain access to it.
 
-.. note:: 
+.. note::
 
  Beginning with ODK Aggregate 1.3.2, upon the initial installation of the server, it is configured to allow unauthenticated (`anonymousUser`) submissions from ODK Collect and unauthenticated browser access to the submissions and forms management functionality of ODK Aggregate.
 
@@ -21,23 +21,26 @@ Click the :guilabel:`Log In` link in the upper right corner of the screen to be 
 Permissions
 ~~~~~~~~~~~~~
 
-If you have not yet changed your super-user password to something other than `aggregate`, the server will display **This server and its data are not secure! Please change the super-user's password!** at the top of the web page. 
+If you have not yet changed your super-user password to something other than the default password of `aggregate`, the server will display a warning at the top of the web page.
+
+.. warning::
+   If you do not change the default password, anyone can take complete control of your server!
 
 .. image:: /img/aggregate-use/warning.*
    :alt: Image showing server not secure warning.
 
-Please visit the :guilabel:`Permissions` sub-tab under the :guilabel:`Site Admin` tab to change this user's password.  
+Please visit the :guilabel:`Permissions` sub-tab under the :guilabel:`Site Admin` tab to change this user's password.
 
 .. image:: /img/aggregate-use/permissions.*
    :alt: Image showing permissions sub-tab.
 
 You can specify additional usernames with browser access to the server under the :guilabel:`Permissions` sub-tab. Privileges are as follows:
 
-- **Data Collector**: able to download forms to ODK Collect and submit data from ODK Collect to ODK Aggregate. 
+- **Data Collector**: able to download forms to ODK Collect and submit data from ODK Collect to ODK Aggregate.
 
 .. note::
 
-   - Only ODK accounts and the anonymousUser can be granted Data Collector rights. 
+   - Only ODK accounts and the anonymousUser can be granted Data Collector rights.
    - The anonymousUser must be granted Data Collector rights to accept submissions from unidentified sources (e.g., from ODK Collect 1.1.5 and earlier, or from ODK Collect 1.1.7 and later if not authenticating).
 
 - **Data Viewer**: able to log onto the ODK Aggregate website, filter and view submissions, and generate csv or kml files for download.
@@ -65,14 +68,14 @@ In the :guilabel:`Preferences` sub-tab under :guilabel:`Site Admin` tab, you can
 
 - **Enketo credentials**: These credentials are used for Enketo webforms integration. To link Enketo with Aggregate, see `this <https://accounts.enketo.org/support/aggregate/>`_.
 - **ODK 2.0 App name**
-      
+
    - *ODK Tables Synchronization Functionality* - check this to enable ODK Tables functionality to download, upload and alter data records within ODK Tables as restricted by table-access privileges granted to the user.
 
 - **Aggregate features**: These settings affect the operations of the server.
-   
+
    - *Disable faster background actions* - check this to reduce App Engine quota usage.
    - *Skip malformed submissions* - check this to ignore corrupted submissions.
 
 .. image:: /img/aggregate-use/preferences-options.*
-   :alt: Image showing other options.   
+   :alt: Image showing other options.
 


### PR DESCRIPTION
Closes #887

Removed very specific text and replace with more generic warning.  Put said warning in a warning block. Clean up some blank spaces

I confirmed this was working by running it locally.