### PR TITLE
Correction for `picker` apperance documentation.

### DIFF
--- a/odk1-src/form-question-types.rst
+++ b/odk1-src/form-question-types.rst
@@ -1849,7 +1849,7 @@ Range widget with picker
 
 type
   :tc:`range`
-type
+appearance
   :tc:`picker`
   
 When the :tc:`picker` appearance is added, the range widget is displayed with a spinner-style select menu in a dialog. The value between horizontal lines is the selected value. Users can scroll the spinner up and down or can tap on the value above to go up by one and on the value below to go down by one.


### PR DESCRIPTION
<!-- ALL PRs MUST BE RELATED TO AN OPEN ISSUE -->
closes #908

#### What is included in this PR?
Replace word `type` with `appearance` for range widget with `picker` appearance. 


<!-- Answer any that apply and delete the others. -->
#### What new issues will need to be opened because of this PR?
None.
#### What is left to be done in the addressed issue?
None.
#### What problems did you encounter?
None.