### PR TITLE
OpenJDK does not seem to include useful root certs

### DIFF
--- a/odk1-src/briefcase-install.rst
+++ b/odk1-src/briefcase-install.rst
@@ -7,7 +7,9 @@ Setting Up ODK Briefcase
 
 .. admonition:: Before you begin...
 
-  Make sure `Java 8 <https://java.com/en/download/>`_ or higher is `installed on your system <https://www.java.com/en/download/help/download_options.xml>`_.
+  Make sure `Oracle Java 8 <https://java.com/en/download/>`_ or higher is `installed on your system <https://www.java.com/en/download/help/download_options.xml>`_.
+
+  We require Oracle's Java because OpenJDK has encryption shortcomings.
   
 #. Download `ODK Briefcase <https://github.com/opendatakit/briefcase/releases/latest>`_.
 


### PR DESCRIPTION
#### What is included in this PR?
Document the solution at https://forum.opendatakit.org/t/odk-briefcase-not-setting-up-properly-after-download/16576. 

The cause seems to be OpenJDK does not include useful root certs.

#### What new issues will need to be opened because of this PR?
We might want to put this language with the Aggregate as well? I'm not sure.