### PR TITLE
Update the range widget to explain how it can be used in filters

### DIFF
--- a/odk1-src/form-question-types.rst
+++ b/odk1-src/form-question-types.rst
@@ -1773,6 +1773,8 @@ Range widgets
 ----------------
 
 Range widgets allow the user to select numbers from within a range that is visually represented as a number line. The parameters of the range widget are defined by :tc:`start`, :tc:`end`, and :tc:`step` values defined in the :th:`parameters` column of your XLSForm. The parameter values can be integers or decimals.
+
+Since Range widget fields are numeric, they can be used to filter secondary instances using numeric operators such as `=` (equals), `<` (less than), `>` (greater than), and their combinations `<=` (less or equal to), and `>=` (greater or equal to).
   
 .. contents:: 
   :local:


### PR DESCRIPTION
addresses #938

#### What is included in this PR?
This should help users to avoid errors by mistakenly using the `selected()` function with range widgets in itemset filters, which won't usually work. The `selected()` function will only work with text data from other `select1` widgets.