### PR TITLE
Document "visible groups" in jump screen

### DIFF
--- a/odk1-src/_static/css/custom.css
+++ b/odk1-src/_static/css/custom.css
@@ -98,6 +98,12 @@ caption .headerlink::after {
     max-width: 45%
 }
 
+/* styling for inline images (e.g. icons within text). */
+
+.rst-content img.icon-inline {
+    margin-bottom: 0;
+}
+
 /* Figure caption styling PR #371 */
 
 .figure{

--- a/odk1-src/collect-filling-forms.rst
+++ b/odk1-src/collect-filling-forms.rst
@@ -99,7 +99,7 @@ If you have a looped group, you can add new instances of that group in the follo
 2. By clicking the "add" button in the :ref:`jump menu <jumping>`:
 
 .. image:: /img/collect-forms/jump-button-add.*
-    :alt: The "add" button.
+    :alt: The "add" button displayed on an Android phone.
     :class: device-screen-vertical
 
 .. _removing_repeats:
@@ -114,7 +114,7 @@ If you have a looped group, you can remove existing instances of that group in t
 2. By clicking the "remove" button in the :ref:`jump menu <jumping>`:
 
 .. image:: /img/collect-forms/jump-button-remove.*
-    :alt: The "remove" button.
+    :alt: The "remove" button displayed on an Android phone.
     :class: device-screen-vertical
 
 .. _navigating:
@@ -186,6 +186,12 @@ The arrow icon (|arrow|) in the top right corner opens the jump menu. From the j
 
 .. image:: /img/collect-forms/jumpmenu.*
     :alt: Jump menu displayed in ODK Collect on an Android phone.
+    :class: device-screen-vertical
+
+If you're inside of a group of questions, you can navigate "up" in the hierarchy using the "go up" button:
+
+.. image:: /img/collect-forms/jump-button-up.*
+    :alt: The "go up" button displayed on an Android phone.
     :class: device-screen-vertical
 
 The jump menu also provides shortcuts to :ref:`add <adding_repeats>` or :ref:`remove <removing_repeats>` instances of looped groups.

--- a/odk1-src/collect-filling-forms.rst
+++ b/odk1-src/collect-filling-forms.rst
@@ -143,17 +143,18 @@ Jumping to questions
 The arrow icon (|arrow|) in the top right corner opens the jump menu. From the jump menu, you can go to any question or go to the beginning/ending of the form.
 
 .. |arrow| image:: /img/collect-forms/jumpicon.*
-             :alt: Opens the jump menu. 
+    :alt: Opens the jump menu.
+    :scale: 25%
+    :class: icon-inline
 
- 
 .. image:: /img/collect-forms/jumpscreen.*
-    :alt: Screen with the arrow icon displayed in ODK Collect on an Android phone. 
+    :alt: Screen with the arrow icon displayed in ODK Collect on an Android phone.
     :class: device-screen-vertical
-  
+
 .. image:: /img/collect-forms/jumpmenu.*
-    :alt: Jump menu displayed in ODK Collect on an Android phone. 
+    :alt: Jump menu displayed in ODK Collect on an Android phone.
     :class: device-screen-vertical
- 
+
 .. note::
 
   If a form contains questions in a looped group, those questions will only appear in the Jump menu once an actual record is created.

--- a/odk1-src/collect-filling-forms.rst
+++ b/odk1-src/collect-filling-forms.rst
@@ -76,6 +76,7 @@ In all cases, buttons below the question text will guide you through providing t
 
   For a (mostly) complete guide to form question appearance, see :doc:`form-question-types`.
 
+.. _removing_answers:
 
 Removing answers
 -------------------
@@ -86,7 +87,34 @@ To remove a response, :gesture:`Long Press` on the :term:`question label`.
   :alt: To remove an answer to a question, long press the question label and follow the on-screen prompts.
   :class: details
 
-  
+Adding instances of looped groups
+-----------------------------------
+
+If you have a looped group, you can add new instances of that group in the following ways:
+
+1. By :ref:`navigating <navigating>` into an empty looped group, or to the next question at the very end of the group, you will automatically be prompted to add a new instance
+
+2. By clicking the "add" button in the :ref:`jump menu <jumping>`:
+
+.. image:: /img/collect-forms/jump-button-add.*
+    :alt: The "add" button.
+    :class: device-screen-vertical
+
+Removing instances of looped groups
+-------------------------------------
+
+If you have a looped group, you can remove existing instances of that group in the following ways:
+
+1. By :gesture:`long pressing` on the :term:`question label` in the same way as for :ref:`removing answers <removing_answers>`
+
+2. By clicking the "remove" button in the :ref:`jump menu <jumping>`:
+
+.. image:: /img/collect-forms/jump-button-remove.*
+    :alt: The "remove" button.
+    :class: device-screen-vertical
+
+.. _navigating:
+
 Navigating the form 
 ------------------------
 
@@ -135,7 +163,8 @@ If you prefer Forward and Back buttons for navigation, you can switch to that in
   
 .. image:: /img/collect-completing-forms/question-screen-with-buttons.* 
   :alt: A question screen in the Collect App. There are now two buttons below the question text, with left (backwards) and right (forwards) buttons.
- 
+
+.. _jumping:
 
 Jumping to questions
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/odk1-src/collect-filling-forms.rst
+++ b/odk1-src/collect-filling-forms.rst
@@ -87,6 +87,8 @@ To remove a response, :gesture:`Long Press` on the :term:`question label`.
   :alt: To remove an answer to a question, long press the question label and follow the on-screen prompts.
   :class: details
 
+.. _adding_repeats:
+
 Adding instances of looped groups
 -----------------------------------
 
@@ -99,6 +101,8 @@ If you have a looped group, you can add new instances of that group in the follo
 .. image:: /img/collect-forms/jump-button-add.*
     :alt: The "add" button.
     :class: device-screen-vertical
+
+.. _removing_repeats:
 
 Removing instances of looped groups
 -------------------------------------
@@ -183,6 +187,8 @@ The arrow icon (|arrow|) in the top right corner opens the jump menu. From the j
 .. image:: /img/collect-forms/jumpmenu.*
     :alt: Jump menu displayed in ODK Collect on an Android phone.
     :class: device-screen-vertical
+
+The jump menu also provides shortcuts to :ref:`add <adding_repeats>` or :ref:`remove <removing_repeats>` instances of looped groups.
 
 .. note::
 

--- a/odk1-src/form-logic.rst
+++ b/odk1-src/form-logic.rst
@@ -486,8 +486,8 @@ Complex example
     
 .. _repeats:
 
-Repeating questions and groups of questions
-==============================================
+Repeating questions and repeating groups of questions
+======================================================
 
 .. note::
   Using repetition in a form is very powerful but can also make training and data analysis more time-consuming. Aggregate does not export repeats so Briefcase or one of the data publishers will be needed to :doc:`transfer data from Aggregate <aggregate-data-access>`. Repeats will be in their own documents and will need to be joined with their parent records for analysis.

--- a/odk1-src/form-logic.rst
+++ b/odk1-src/form-logic.rst
@@ -482,8 +482,34 @@ Complex example
     integer, b, b =,
     calculate, a_plus_b, ,"if(${a} != '' and ${b} != '', ${a} + ${b}, '')"
     note, display_sum, a + b = ${a_plus_b}, 	
-  
-    
+
+.. _groups:
+
+Groups of questions
+====================
+
+To group questions, use the :tc:`begin_group...end_group` syntax.
+
+.. rubric:: XLSForm (Question group)
+
+.. csv-table:: survey
+  :header: type, name, label
+
+  begin_group, my_group, My text widgets
+  text, question_1, Text widget 1
+  text, question_2, These questions will both be grouped together
+  end_group, ,
+
+If given a :th:`label`, groups will be visible in the form path to help orient the user
+(e.g. :guilabel:`My text widgets > Text widget 1`).
+
+If given a :th:`label` and also a :th:`ref`, groups will be visible as clickable items in the jump menu:
+
+.. image:: /img/form-logic/jump-menu-groups.*
+  :alt: The jump menu with a few grouped questions.
+
+Groups can also be a convenient way to :ref:`conditionally show certain questions <relevants>`.
+
 .. _repeats:
 
 Repeating questions and groups of questions

--- a/odk1-src/form-logic.rst
+++ b/odk1-src/form-logic.rst
@@ -486,8 +486,8 @@ Complex example
     
 .. _repeats:
 
-Repeating questions and repeating groups of questions
-======================================================
+Repeating questions and groups of questions
+==============================================
 
 .. note::
   Using repetition in a form is very powerful but can also make training and data analysis more time-consuming. Aggregate does not export repeats so Briefcase or one of the data publishers will be needed to :doc:`transfer data from Aggregate <aggregate-data-access>`. Repeats will be in their own documents and will need to be joined with their parent records for analysis.

--- a/odk1-src/form-logic.rst
+++ b/odk1-src/form-logic.rst
@@ -508,6 +508,11 @@ If given a :th:`label` and also a :th:`ref`, groups will be visible as clickable
 .. image:: /img/form-logic/jump-menu-groups.*
   :alt: The jump menu with a few grouped questions.
 
+.. warning::
+
+  If you use ODK Build v0.3.4 or earlier, your groups will not be visible in the jump menu.
+  The items inside the groups will display as if they weren't grouped at all.
+
 Groups can also be a convenient way to :ref:`conditionally show certain questions <relevants>`.
 
 .. _repeats:

--- a/odk1-src/form-logic.rst
+++ b/odk1-src/form-logic.rst
@@ -500,20 +500,29 @@ To group questions, use the :tc:`begin_group...end_group` syntax.
   text, question_2, These questions will both be grouped together
   end_group, ,
 
-If given a :th:`label`, groups will be visible in the form path to help orient the user
-(e.g. :guilabel:`My text widgets > Text widget 1`).
+.. note::
 
-If given a :th:`label` and also a :th:`ref`, groups will be visible as clickable items in the jump menu:
-
-.. image:: /img/form-logic/jump-menu-groups.*
-  :alt: The jump menu with a few grouped questions.
+  If a group has a label, it's considered a "presentation group".
+  If it doesn't have a label, it may be considered a "logical group".
+  Read more on the `XForms Spec <https://opendatakit.github.io/xforms-spec/#groups>`_.
 
 .. warning::
 
   If you use ODK Build v0.3.4 or earlier, your groups will not be visible in the jump menu.
   The items inside the groups will display as if they weren't grouped at all.
 
-Groups can also be a convenient way to :ref:`conditionally show certain questions <relevants>`.
+If given a :th:`label`, groups will be visible in the form path to help orient the user
+(e.g. :guilabel:`My text widgets > Text widget 1`).
+
+Labeled groups will also be visible as clickable items in the jump menu:
+
+.. image:: /img/form-logic/jump-menu-groups.*
+  :alt: The jump menu with a few grouped questions.
+
+Groups without labels can be helpful for organizing questions in a way that's invisible to the user.
+This technique can be helpful for internal organization of the form.
+
+Logical groups can be a convenient way to :ref:`conditionally show certain questions <relevants>`.
 
 .. _repeats:
 

--- a/odk1-src/img/collect-forms/jump-button-add.png
+++ b/odk1-src/img/collect-forms/jump-button-add.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d5b536d4950611fd1fea760e4d7a8c435dc3089b09f4816d54ae8c70a03cc02
+size 38697

--- a/odk1-src/img/collect-forms/jump-button-remove.png
+++ b/odk1-src/img/collect-forms/jump-button-remove.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c09360be6c9f841970397e1f9dda4029d43b5690e6d7b6b81c05507a70b5f0ce
+size 72126

--- a/odk1-src/img/collect-forms/jump-button-up.png
+++ b/odk1-src/img/collect-forms/jump-button-up.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:303199b50ea9459c05bc9dc1ea741138cebb9db0f5da4d0f10d08a83487cb19b
+size 66020

--- a/odk1-src/img/collect-forms/jumpicon.png
+++ b/odk1-src/img/collect-forms/jumpicon.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8108066dd8f4cd59605e6b3a83dd1fcbb20d80f1fa74a68950c34b0f952af6f8
-size 751
+oid sha256:f553bfa4bac95ced1521ea0d9b2140087ea1872e5cba056b502816b7ca2338ff
+size 716

--- a/odk1-src/img/collect-forms/jumpmenu.png
+++ b/odk1-src/img/collect-forms/jumpmenu.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d98dfff5e5dc1eb78ead52792c035bf7981708207d79a069c2e96da947f07c67
-size 219298
+oid sha256:903fb205d69bc1976f219b6ad26af72f1d2c8e021d13f8b5ea793465b9bd3ed0
+size 96735

--- a/odk1-src/img/collect-forms/jumpscreen.png
+++ b/odk1-src/img/collect-forms/jumpscreen.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:40df8b0d079ed55a3e146d133334219d35e8c6eefefc87a8730907aac79422f0
-size 52258
+oid sha256:4b67d723340a5afb8b6b117d6a861c69a0fd0ded52b664277be1a8438ca0e006
+size 34449

--- a/odk1-src/img/form-logic/jump-menu-groups.png
+++ b/odk1-src/img/form-logic/jump-menu-groups.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c4420971543591461631dee50c01d986cde3038f3c44ee6fd058b7971f34053
+size 120200


### PR DESCRIPTION
Addresses https://github.com/opendatakit/docs/issues/931

#### Changes

- Added `form-logic.html#groups-of-questions`
- Added `collect-filling-forms.html#adding-instances-of-looped-groups`
    - With screenshot of "add" button
- Added `collect-filling-forms.html#removing-instances-of-looped-groups`
    - With screenshot of "remove" button
- Updated `collect-filling-forms.html#jumping-to-questions`
    - Updated the screenshots to show new icons and grouping
    - Added screenshot of "up" button
    - Linked to new `adding`/`removing` sections above

#### Notes

- ~~How do we explain to users what a `ref` is?~~
- ~~How do they add a `ref` in [Build](https://build.opendatakit.org/)?~~
