### PR TITLE
Moved documentation from technical guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ You can also use the `run-task` script described above to build both ODK 1 and O
  
 We highly recommend you use a virtual environment like [virtualenv](https://virtualenv.pypa.io/en/stable/) or a Python version management like [pyenv](https://github.com/pyenv/pyenv). (Type `python --version` to see your current version.)
 
+- Instructions for setting up virtual environment:
+
+
 ### Cloning the repo
 
 Clone the docs repo and make sure all the requirements are installed:

--- a/README.md
+++ b/README.md
@@ -86,6 +86,71 @@ We highly recommend you use a virtual environment like [virtualenv](https://virt
 
 - Instructions for setting up virtual environment:
 
+   #. Set up a virtual environment
+
+      A `virtual environment`_ is a Python construct
+      that lets you download and install tools for a specific project
+      without installing them for your entire computer.
+
+      .. _virtual environment: https://docs.python.org/3/tutorial/venv.html
+
+      #. Create the virtual environment.
+
+         .. tabs::
+   
+            .. group-tab:: Bash
+
+               .. code:: console
+
+                  /odk/ $ python3 -m venv odkenv
+
+            .. group-tab:: PowerShell
+
+               .. code:: powershell
+
+                  /odk/ > python -m venv odkenv
+
+      #. Activate the virtual environment.
+
+         .. tabs::
+
+            .. group-tab:: Bash
+      
+               .. code:: console
+
+                  /odk/ $ source odkenv/bin/activate
+                  (odkenv) /odk/ $
+
+            .. group-tab:: PowerShell
+
+               .. code:: console
+
+                  /odk/ > source odkenv/bin/activate
+                  (odkenv) /odk/ >
+
+         The ``(odkenv)`` before the prompt shows that the virtual environment is active.
+         You will need to have this active any time you are working on the docs.
+      
+         If the file cannot be found, your activate file may be located under odkenv/scripts/activate.
+
+         Later, to deactivate the virtual environment:
+
+         .. tabs::
+
+            .. group-tab:: Bash
+      
+               .. code:: console
+
+                  (odkenv) /odk/ $ deactivate
+                  /odk/ $
+
+            .. group-tab:: PowerShell
+
+               .. code:: console
+
+                  (odkenv) /odk/ > deactivate
+                  /odk/ >
+		  
 
 ### Cloning the repo
 

--- a/README.md
+++ b/README.md
@@ -86,8 +86,6 @@ We highly recommend you use a virtual environment like [virtualenv](https://virt
 
 - Instructions for setting up virtual environment:
 
-   #. Set up a virtual environment
-
       A `virtual environment`_ is a Python construct
       that lets you download and install tools for a specific project
       without installing them for your entire computer.

--- a/shared-src/docs-tech-guide.rst
+++ b/shared-src/docs-tech-guide.rst
@@ -171,13 +171,17 @@ Initial Setup
 
 .. note::
 
-  Developer and authoring tools 
-  have a lot of options and alternatives. 
+  We generally recommend `starting with the Docker platform`_ for editing
+  docs unless you already have a Sphinx environment set up. 
   Local tools and workflows presented in this guide 
   are what the authors feel would be easiest 
   for newcomers and those unfamiliar with open source.
   
+  However, developer and authoring tools 
+  have a lot of options and alternatives.   
   You should feel free to use your preferred tools.
+  
+  .. _starting with the Docker platform: https://github.com/opendatakit/docs/blob/master/README.md#using-docker
 
 Before you begin working the first time
 you will need to install a few tools 

--- a/shared-src/docs-tech-guide.rst
+++ b/shared-src/docs-tech-guide.rst
@@ -31,7 +31,7 @@ Read about the project and the community at `Open Data Kit's website`_.
 Get started with the docs by going to the `ODK Docs GitHub README`_.
 
 .. _Open Data Kit's website: http://opendatakit.org
-.. _ODK Docs on GitHub: https://github.com/opendatakit/docs/blob/master/README.md
+.. _ODK Docs GitHub README: https://github.com/opendatakit/docs/blob/master/README.md
 
 .. _odk-accounts:
 

--- a/shared-src/docs-tech-guide.rst
+++ b/shared-src/docs-tech-guide.rst
@@ -28,6 +28,7 @@ Learn a little about Open Data Kit
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Read about the project and the community at `Open Data Kit's website`_.
+
 Get started with the docs by going to the `ODK Docs GitHub README`_.
 
 .. _Open Data Kit's website: http://opendatakit.org

--- a/shared-src/docs-tech-guide.rst
+++ b/shared-src/docs-tech-guide.rst
@@ -553,9 +553,10 @@ on any computer.
 
             If you get an error here, something went wrong.
             Try running the installer again. 
-            You may also have to add python to your windows search path.
-            You can do this by going to advanced system settings -> Environmental Variables
-            -> Edit System Variables, then adding the path to the directory containing python.
+            You may also have to add Python to your Windows search path.
+            You can do this by going to 
+            :menuselection:`Advanced System Settings -> Environmental Variables -> Edit System Variables`,
+            then adding the path to the directory containing Python.
             If the problem persists, and you can't debug it yourself,
             asks us about it on |odk-slack|_.
 

--- a/shared-src/docs-tech-guide.rst
+++ b/shared-src/docs-tech-guide.rst
@@ -28,8 +28,10 @@ Learn a little about Open Data Kit
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Read about the project and the community at `Open Data Kit's website`_.
+Get started with the docs by going to the `ODK Docs GitHub README`_.
 
 .. _Open Data Kit's website: http://opendatakit.org
+.. _ODK Docs on GitHub: https://github.com/opendatakit/docs/blob/master/README.md
 
 .. _odk-accounts:
 
@@ -65,8 +67,8 @@ and the :ref:`ODK Forum <join-forum>`
    .. _get-gh-account:
 
    `GitHub`_ is a popular code storage and collaboration platform.
-   You will need a GitHub account to contribute to Open Date Kit documentation,
-   or any other Open Date Kit projects.
+   You will need a GitHub account to contribute to Open Data Kit documentation,
+   or any other Open Data Kit projects.
 
    - `Open Data Kit on GitHub`_
    - `ODK Docs on GitHub`_

--- a/shared-src/docs-tech-guide.rst
+++ b/shared-src/docs-tech-guide.rst
@@ -546,6 +546,9 @@ on any computer.
 
             If you get an error here, something went wrong.
             Try running the installer again. 
+            You may also have to add python to your windows search path.
+            You can do this by going to advanced system settings -> Environmental Variables
+            -> Edit System Variables, then adding the path to the directory containing python.
             If the problem persists, and you can't debug it yourself,
             asks us about it on |odk-slack|_.
 
@@ -625,6 +628,8 @@ on any computer.
 
       The ``(odkenv)`` before the prompt shows that the virtual environment is active.
       You will need to have this active any time you are working on the docs.
+      
+      If the file cannot be found, your activate file may be located under odkenv/scripts/activate.
 
       Later, to deactivate the virtual environment:
 


### PR DESCRIPTION
#### What is included in this PR?
Directed users in the technical guide away from starting the outdated Python/Sphinx instructions towards the Docker instructions in the README file.

Copied instructions for setting up virtual environment from technical guide to README file.

Minor fixes.
