### PR TITLE
Makes example column heading lowercase

### DIFF
--- a/odk2-src/xlsx-converter-reference.rst
+++ b/odk2-src/xlsx-converter-reference.rst
@@ -455,7 +455,7 @@ A sample **settings** worksheet might look like this:
   :header-rows: 1
 
   * - setting_name
-    - Value
+    - value
     - :th:`display.title.text`
     - display.locale.text
     - display.locale.text.hindi


### PR DESCRIPTION
As per previous forum discussion: https://forum.opendatakit.org/t/xlsx-converter-typeerror-cannot-read-property-length-of-undefined/3234/9, this pull request changes an uppercase column heading to lowercase on an example settings sheet.

Should I open a new issue first?
<!-- ALL PRs MUST BE RELATED TO AN OPEN ISSUE -->
closes #
<!-- OR -->
addresses #


#### What is included in this PR?
Changes an uppercase column heading to lowercase on an example settings sheet. This could prevent future user errors like https://forum.opendatakit.org/t/xlsx-converter-typeerror-cannot-read-property-length-of-undefined/3234/8. 


<!-- Answer any that apply and delete the others. -->
#### What new issues will need to be opened because of this PR?
None.
#### What is left to be done in the addressed issue?
The issue is addressed.
#### What problems did you encounter?
None.