### PR TITLE
Publish to odk-x directory, redirect incoming links

### DIFF
--- a/odk2-config/s3_website.yml
+++ b/odk2-config/s3_website.yml
@@ -1,6 +1,6 @@
 s3_bucket: odk2-docs-web
 s3_endpoint: us-west-2
-s3_key_prefix: odk2
+s3_key_prefix: odk-x
 
 site: ../odk2-build
 
@@ -27,3 +27,10 @@ cloudfront_distribution_config:
       - docs.opendatakit.org
 
 cloudfront_wildcard_invalidation: true
+
+routing_rules:
+  - condition:
+      key_prefix_equals: odk2
+    redirect:
+      replace_key_with: odk-x
+      http_redirect_code: 301


### PR DESCRIPTION
#### What is included in this PR?
* Publish the docs to odk-x folder on S3. This folder has already been created.
* Redirect all incoming links form odk2 to odk-x

#### What is left to be done in the addressed issue?
After merge:
1. Remove the CloudFront behavior redirection
2. Remove the odk folder on S3