### PR TITLE
Added hint for using Git on windows

### DIFF
--- a/odk2-src/sync-endpoint.rst
+++ b/odk2-src/sync-endpoint.rst
@@ -44,6 +44,8 @@ ODK Sync Endpoint requires a database and a *LDAP* directory, you could follow t
 
   All of the following commands should be run on your server.
 
+  If you are using git on Windows, make sure git is configured with "core.autocrlf=false" - otherwise it will convert line endings with LF to CRLF, which will cause problems with the .sh-files when used in the Docker containers, thus preventing odk/sync-endpoint from starting and instead just returning with an ":invalid argument"-error. 
+
 Setup instructions:
 
   1. Choose a directory to store you endpoint in. In that directory, run:
@@ -51,10 +53,7 @@ Setup instructions:
   .. code-block:: console
 
     $ git clone https://github.com/opendatakit/sync-endpoint-default-setup
-.. note::
-
-  If you are using Git on Windows, pay attention to how line endings are handled. Git configured with "core.autocrlf=true" will convert LF to CRLF, which will cause problems with the .sh-files when used in the Docker containers, thus preventing odk/sync-endpoint from starting and instead just returning with an ":invalid argument"-error. 
-
+    
   2. Navigate into the the "sync-endpoint-default-setup" directory
   
   3. Checkout the sync-endpoint code by running:

--- a/odk2-src/sync-endpoint.rst
+++ b/odk2-src/sync-endpoint.rst
@@ -51,6 +51,9 @@ Setup instructions:
   .. code-block:: console
 
     $ git clone https://github.com/opendatakit/sync-endpoint-default-setup
+.. note::
+
+  If you are using Git on Windows, pay attention to how line endings are handled. Git configured with "core.autocrlf=true" will convert LF to CRLF, which will cause problems with the .sh-files when used in the Docker containers, thus preventing odk/sync-endpoint from starting and instead just returning with an ":invalid argument"-error. 
 
   2. Navigate into the the "sync-endpoint-default-setup" directory
   

--- a/shared-src/spelling_wordlist.txt
+++ b/shared-src/spelling_wordlist.txt
@@ -19,6 +19,7 @@ Autoadvance
 autoadvance
 Autocomplete
 autocomplete
+autocrlf
 AWS
 backend
 Backends


### PR DESCRIPTION
Hello,

Sorry if I'm not following procedure - I am new to this, so please bear with me :)
I added a warning about Git for windows substituting LF with CRLF, since that will cause the containers to be unable to start. Perhaps it could be useful to someone else - it did at least cost me quite a lot of time to figure out that this was the issue ;-)

(on a side note; it is mentioned that sync-endpoints should be compiled with java jdk 8, but I could only get it working with jdk 12? If I used jdk 8, it crashed with a lot of "duplicate class definition" errors - this could however also be a side effect of my messing up of line endings with autocrlf=true in git)

#### What is included in this PR?
A note in the documentaion
