### PR TITLE
Only newest form versions is visible in Collect

### DIFF
--- a/odk1-src/form-update.rst
+++ b/odk1-src/form-update.rst
@@ -167,19 +167,13 @@ These are the :file:`.xlsx` files for the above forms:
 
 .. note::
 
-  ODK Collect treats different versions of the same form completely independently. It won't explicitly notify the users of the existence of new versions. When a user tries to get new blank forms, a form with updated version will be selected by default in the list but there will be no explicit notification unless a user tries to get new blank forms.
+  When a user tries to get new blank forms, a form with updated version will be selected by default in the list and will contain an additional message to indicate it's an update.
 
   .. image:: /img/form-update/get-new-version.png
    :alt: Image showing new version 2017120708 selected in the list of forms to be downloaded.
    :class: device-screen-vertical
 
-  |
-
-  Both versions of the form exist in the device of the user and the user will be allowed to fill an older version and submit the form to the Aggregate server. You will need to manually delete an older version from your device. 
-
-  .. image:: /img/form-update/two-version-form.png
-   :alt: Image showing two versions 2017120700 and 2017120701 in the form list.
-   :class: device-screen-vertical
+  Both versions of the form will exist in the device of the user but only the newer one will be visible on the list. Thanks to that the user will be able to edit forms he has started using the older version and upload them to the server, but new forms will be started using the newest available form version.
 
 .. _replace-form:
 

--- a/odk1-src/img/form-update/get-new-version.png
+++ b/odk1-src/img/form-update/get-new-version.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ce67cef20e5f675d1f7fdc86cf4c260880f2979e0e162623e6c0eb77f6b1d595
-size 136036
+oid sha256:adc1c23a3c687358b3738833c46956aa257c9eb08526ddbd4b53ad79dc38b1d2
+size 64336

--- a/odk1-src/img/form-update/two-version-form.png
+++ b/odk1-src/img/form-update/two-version-form.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0d3a0398c0c2b627a38156756853aa3dbc710d65a0d101bcfca81cdf0bc07f0a
-size 117612


### PR DESCRIPTION
addresses #710 

#### What is included in this PR?
The pr documents the change we implemented in collect:
-only the newest form version is displayed on the form list.
-updates have an additional message on the list of forms we can download