### PR TITLE
Include steps to use own Sentry error logging

### DIFF
--- a/odk1-src/central-install-digital-ocean.rst
+++ b/odk1-src/central-install-digital-ocean.rst
@@ -190,7 +190,7 @@ ODK Central ships with a basic EXIM server bundled to forward mail out to the in
 
 .. _central-install-digital-ocean-sentry:
 
-Disabling or customising Sentry
+Disabling or customizing Sentry
 -------------------------------
 
 By default, we enable `Sentry error logging <https://sentry.io>`_ on the backend server, which provides the ODK Central development team with an anonymized log of unexpected programming errors that occur while your server is running. This information is only visible to the development team and should never contain any of your user or form data, but if you feel uncomfortable with this anyway, you can take the following steps to disable Sentry:
@@ -204,21 +204,19 @@ If on the other hand you wish to use your own Sentry instance, take these steps:
 2. The new project will generate a ``DSN`` of the format ``https://SENTRY_KEY@sentry.io/SENTRY_PROJECT``.
 3. In ``files/service/config.json.template``, replace ``SENTRY_KEY`` and ``SENTRY_PROJECT`` with the values from step 2. 
 
-  ::
-
-  {
-    "default": {
-      "database": {...},
-      "email": {...},
-      "env": {...},
-      "external": {
-        "sentry": {
-          "key": "SENTRY_KEY",
-          "project": "SENTRY_PROJECT"
+    {
+      "default": {
+        "database": {...},
+        "email": {...},
+        "env": {...},
+        "external": {
+          "sentry": {
+            "key": "SENTRY_KEY",
+            "project": "SENTRY_PROJECT"
+          }
         }
       }
     }
-  }
 
 The error logs sent to Sentry (if enabled) are also being written to ``/var/log/odk/stderr.log`` in the running backend container.
 

--- a/odk1-src/central-install-digital-ocean.rst
+++ b/odk1-src/central-install-digital-ocean.rst
@@ -190,8 +190,8 @@ ODK Central ships with a basic EXIM server bundled to forward mail out to the in
 
 .. _central-install-digital-ocean-sentry:
 
-Customizing Sentry
-------------------
+Disabling or Customizing Sentry
+-------------------------------
 
 By default, we enable `Sentry error logging <https://sentry.io>`_ on the backend server, which provides the ODK Central development team with an anonymized log of unexpected programming errors that occur while your server is running. This information is only visible to the development team and should never contain any of your user or form data, but if you feel uncomfortable with this anyway, you can take the following steps to disable Sentry:
 

--- a/odk1-src/central-install-digital-ocean.rst
+++ b/odk1-src/central-install-digital-ocean.rst
@@ -190,13 +190,37 @@ ODK Central ships with a basic EXIM server bundled to forward mail out to the in
 
 .. _central-install-digital-ocean-sentry:
 
-Disabling Sentry
-----------------
+Disabling or customising Sentry
+-------------------------------
 
-By default, we enable `Sentry error logging <https://sentry.io>`_ on the backend server, which provides the ODK Central development team with an anonymized log of unexpected programming errors that occur while your server is running. This information is only visible to the development team and should never any of your user or form data, but if you feel uncomfortable with this anyway, you can take the following steps to disable Sentry:
+By default, we enable `Sentry error logging <https://sentry.io>`_ on the backend server, which provides the ODK Central development team with an anonymized log of unexpected programming errors that occur while your server is running. This information is only visible to the development team and should never contain any of your user or form data, but if you feel uncomfortable with this anyway, you can take the following steps to disable Sentry:
 
 1. Edit the file ``files/service/config.json.template`` and remove the ``sentry`` lines, starting with ``"sentry": {`` through the next three lines until you remove the matching ``}``.
 2. Build and run: ``docker-compose build service`` and ``systemctl restart docker-compose@central``.
+
+If on the other hand you wish to use your own Sentry instance, take these steps:
+
+1. Create a free account on `Sentry <https://sentry.io>`_, and create a new ``nodejs`` project.
+2. The new project will generate a ``DSN`` of the format ``https://SENTRY_KEY@sentry.io/SENTRY_PROJECT``.
+3. In ``files/service/config.json.template``, replace ``SENTRY_KEY`` and ``SENTRY_PROJECT`` with the values from step 2. 
+
+  ::
+
+  {
+    "default": {
+      "database": {...},
+      "email": {...},
+      "env": {...},
+      "external": {
+        "sentry": {
+          "key": "SENTRY_KEY",
+          "project": "SENTRY_PROJECT"
+        }
+      }
+    }
+  }
+
+The error logs sent to Sentry (if enabled) are also being written to ``/var/log/odk/stderr.log`` in the running backend container.
 
 .. _central-install-digital-ocean-custom-ssl:
 

--- a/odk1-src/central-install-digital-ocean.rst
+++ b/odk1-src/central-install-digital-ocean.rst
@@ -204,7 +204,7 @@ If on the other hand you wish to use your own Sentry instance, take these steps:
 2. The new project will generate a ``DSN`` of the format ``https://SENTRY_KEY@sentry.io/SENTRY_PROJECT``.
 3. In ``files/service/config.json.template``, replace ``SENTRY_KEY`` and ``SENTRY_PROJECT`` with the values from step 2. 
 
-.. code-block:: json
+.. code-block:: rst
 
   {
     "default": {

--- a/odk1-src/central-install-digital-ocean.rst
+++ b/odk1-src/central-install-digital-ocean.rst
@@ -190,8 +190,8 @@ ODK Central ships with a basic EXIM server bundled to forward mail out to the in
 
 .. _central-install-digital-ocean-sentry:
 
-Disabling or customizing Sentry
--------------------------------
+Customizing Sentry
+------------------
 
 By default, we enable `Sentry error logging <https://sentry.io>`_ on the backend server, which provides the ODK Central development team with an anonymized log of unexpected programming errors that occur while your server is running. This information is only visible to the development team and should never contain any of your user or form data, but if you feel uncomfortable with this anyway, you can take the following steps to disable Sentry:
 

--- a/odk1-src/central-install-digital-ocean.rst
+++ b/odk1-src/central-install-digital-ocean.rst
@@ -204,19 +204,21 @@ If on the other hand you wish to use your own Sentry instance, take these steps:
 2. The new project will generate a ``DSN`` of the format ``https://SENTRY_KEY@sentry.io/SENTRY_PROJECT``.
 3. In ``files/service/config.json.template``, replace ``SENTRY_KEY`` and ``SENTRY_PROJECT`` with the values from step 2. 
 
-    {
-      "default": {
-        "database": {...},
-        "email": {...},
-        "env": {...},
-        "external": {
-          "sentry": {
-            "key": "SENTRY_KEY",
-            "project": "SENTRY_PROJECT"
-          }
+.. code-block:: json
+
+  {
+    "default": {
+      "database": {...},
+      "email": {...},
+      "env": {...},
+      "external": {
+        "sentry": {
+          "key": "SENTRY_KEY",
+          "project": "SENTRY_PROJECT"
         }
       }
     }
+  }
 
 The error logs sent to Sentry (if enabled) are also being written to ``/var/log/odk/stderr.log`` in the running backend container.
 


### PR DESCRIPTION
Stung by a config error leading to spurious [error messages in the frontend](https://github.com/opendatakit/central/issues/81), having Sentry error logging available is immensely useful. 

Addresses https://github.com/opendatakit/central/issues/81


#### What is included in this PR?
An update to docs on how to configure own Sentry error logging.

<!-- Answer any that apply and delete the others. -->
#### What new issues will need to be opened because of this PR?

#### What is left to be done in the addressed issue?
Decide on best practice to configure Sentry logging:
Is hacking the default.json (as described in this PR - parallel to disabling Sentry) a good way, or should the docs advise to provide a custom Sentry config a local.json instead? The latter is how we run Central on Kubernetes.

#### What problems did you encounter?
A lack of logging (fixed by having own Sentry logs now) and a slow moment where I forgot to check `/var/log/(anything useful)` inside the running container. Needed a reminder from @issa-tseng which pointed me to the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opendatakit/docs/1061)
<!-- Reviewable:end -->
