### PR TITLE
Add instructions for re-uploading forms

### DIFF
--- a/odk1-src/briefcase-using.rst
+++ b/odk1-src/briefcase-using.rst
@@ -66,6 +66,14 @@ Briefcase will ask for the directory on your computer where you have placed Coll
 
   When pulling from Collect, Briefcase pulls incomplete, saved, or finalized forms. After you pull forms into Briefcase, it is important that you delete them from Collect. Otherwise, the next time you pull, you will create duplicates.
 
+.. tip::
+
+  If you have Android developer tools installed, another option is to use :doc:`the Android Debug Bridge <collect-adb>` to pull filled forms:
+
+  .. code-block:: console
+
+      $ adb pull /sdcard/odk/instances
+
 .. _pull-form-definition:
 
 Form definition

--- a/odk1-src/collect-forms.rst
+++ b/odk1-src/collect-forms.rst
@@ -147,17 +147,21 @@ This will reopen the form instance, which you are then free to edit. Form instan
 
 .. _uploading-forms:
 
-Uploading Finalized Forms
-===========================
+Aggregating Finalized Forms
+============================
 
-Eventually, you will want to upload completed form instances for analysis and data aggregation. 
+To perform analysis on data collected with the Collect app, you will need to get the filled forms off of the devices. Generally, this is done by uploading them to an ODK server or Google Sheets. To do this, you will first need to :doc:`configure a server <collect-connect>`.
 
-Doing this from within the Collect app marks the forms as :formstate:`sent`. :formstate:`Sent` forms are no longer editable, but they remain viewable until they are deleted. 
+In some cases, you may want to :ref:`pull filled forms directly from a device <pulling-forms-with-briefcase>`. This can be simpler than setting up a server if you are only using a small number of devices or when there is no Internet access. It can also be helpful to recover from submission failures.
 
-Uploading to Aggregate or Google Drive
+.. _uploading-to-aggregate-or-google-drive:
+
+Uploading Finalized Forms to a Server
 ----------------------------------------
 
-If you are connected to :doc:`an ODK Aggregate server  <collect-connect-aggregate>` or :doc:`Google Drive Account  <collect-connect-google>`, use :guilabel:`Send Finalized Forms` to upload :formstate:`Finalized` form instances. 
+If you are connected to :doc:`a server <collect-connect-aggregate>` or :doc:`Google Drive Account <collect-connect-google>`, use :guilabel:`Send Finalized Forms` to upload :formstate:`Finalized` form instances.
+
+Uploading a filled form from within the Collect app marks that form as :formstate:`sent`. :formstate:`Sent` forms are no longer editable, but they remain viewable until they are deleted. 
 
 .. image:: /img/collect-forms/main-menu-send-finalized.* 
   :alt: The Main Menu of the Collect app. The *Send Finalized Form* option is circled in red.
@@ -173,16 +177,26 @@ If you are connected to :doc:`an ODK Aggregate server  <collect-connect-aggregat
 
   Using Google Drive as a server, filled forms are sent to the first sheet in a given spreadsheet, no matter what its name is. If you use one spreadsheet to keep a form definition and to collect filled forms make sure the sheet you expect to be filled is in the first place.
 
-Pulling forms with Briefcase
--------------------------------
+.. _uploading-previously-sent-forms:
 
-For local form management, use :doc:`ODK Briefcase  <briefcase-using>` to pull :formstate:`Finalized` form instances to your local computer.
+Uploading Previously-Sent Forms
+--------------------------------
+
+If you can't find a submission that you expect on your server or need to re-send a submission for other reasons, you can change the view of the :guilabel:`Send Finalized Forms` screen to show both sent and unsent forms.
+
+To show sent and unsent forms:
+  :menuselection:`⋮ --> Change View --> Show Sent and Unsent Forms`
+
+.. image:: /img/collect-forms/send-finalized-change-view.*
+  :alt: The Send Finalized Forms screen of the Collect app. The *Change View* option is circled in red.
 
 
-Pulling forms with ``adb``
-----------------------------
+.. _pulling-forms-with-briefcase:
 
-You can copy form instances from the device using :command:`adb pull`, however this will not update the state of the form to :formstate:`Sent`.
+Pulling Forms Into Briefcase
+-----------------------------
+
+:doc:`ODK Briefcase  <briefcase-using>` is a desktop application that can be used to aggregate filled forms. You will first need to :ref:`transfer the filled forms to your computer <pull-from-collect>`. This will not update the state of the form to :formstate:`Sent`.
 
 .. _deleting-forms:
 

--- a/odk1-src/img/collect-forms/send-finalized-change-view.png
+++ b/odk1-src/img/collect-forms/send-finalized-change-view.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09fd60c5901b290ae5c2bf1e179395862141da5a5169e36114a174408f2122bf
+size 30988


### PR DESCRIPTION
closes #1020 

#### What is included in this PR?
The primary focus of this PR is the new section [here](https://github.com/opendatakit/docs/compare/master...lognaturel:issue-1020?expand=1#diff-c15c6b31fabf0edc793f01e0f451b1c1R182). As I was writing instructions for re-uploading forms, I got confused because the "uploading finalized forms" section included information both on uploading submissions to a server and on transferring them to a local machine. I renamed that section to "Aggregating Finalized Forms" and verified that the #uploading-forms target still works.

Then I reworked the introduction because the information about formstate was given without context.

Then I reworked the local form management section because it didn't really make sense.

I used ImageOptim to limit the size of the image.

I ran this and verified that everything looks as expected, including links.

<img width="709" alt="Screen Shot 2019-08-07 at 11 42 20 AM" src="https://user-images.githubusercontent.com/967540/62648847-74aecb00-b908-11e9-9516-ea4697266d0e.png">

