### PR TITLE
Update map settings and offline maps sections for new Collect maps settings and Mapbox support for vector MBTiles files

### DIFF
--- a/odk1-src/collect-offline-maps.rst
+++ b/odk1-src/collect-offline-maps.rst
@@ -5,6 +5,7 @@
   Basemaps
   geospatial
   heatmaps
+  mapbox
   Mapbox
   pbf
   tileset
@@ -44,6 +45,8 @@ If the tileset has transparency (PNG or PBF tiles only), the selected basemap wi
 
 Getting map tilesets
 -------------------------
+For non-commercial community mapping activities, `Mapbox <https://www.mapbox.com/maps/>`_ can arrange for offline MBTiles, including processed streets, satellite, and custom data. Contact community[at]mapbox.com for offline Terms of Service exemptions and to receive technical guidance.
+
 `OpenMapTiles <https://openmaptiles.org/>`_ hosts many free map tile files that can be used in Collect.
 
 To create MBTiles files, use one of the `compatible applications <https://github.com/mapbox/mbtiles-spec/wiki/Implementations#applications>`_ . Commonly used free software packages are `TileMill <https://tilemill-project.github.io/tilemill/>`_ and `QGIS <https://qgis.org/en/site/>`_ with the `QTiles plugin <https://github.com/nextgis/QTiles#qtiles>`_.

--- a/odk1-src/collect-offline-maps.rst
+++ b/odk1-src/collect-offline-maps.rst
@@ -1,44 +1,68 @@
 .. spelling:: 
   basemap
+  Basemap
+  basemaps
+  Basemaps
   geospatial
   heatmaps
   Mapbox
   pbf
+  tileset
+  tilesets
 
 Using Offline Maps
 ====================
 
-Collect's :ref:`location-widgets` can be configured to display different maps. To use online maps, :ref:`set the mapping engine and basemap <mapping-settings>` in :ref:`interface-settings`. Users will need to be online to load questions with maps.
+Collect's :ref:`geopoint <geopoint-maps>`, :ref:`geotrace <geotrace-widget>`, and :ref:`geoshape <geoshape-widget>` questions can be configured to display different map data. To use online basemaps, :ref:`set the basemap source and style <basemap-settings>` in :guilabel:`mapping-settings`. Users will need to be online to load questions with maps.
 
-Offline maps are useful for low-connectivity environments or to present custom geospatial data. Use them to display high-resolution imagery, annotated maps, heatmaps, and more. ODK Collect can display any map layer saved as a set of tiles in the `MBTiles format <https://github.com/mapbox/mbtiles-spec>`_. Tiles are images that represent a subset of a map. The only limitation is that tile data in Mapbox's pbf format are not supported.
+Offline layers are useful to present custom geospatial data layered over standard basemaps or as basemaps for low-connectivity environments. Use them to display high-resolution imagery, annotated maps, heatmaps, and more. ODK Collect can display any map layer saved as a set of tiles in the `MBTiles format <https://github.com/mapbox/mbtiles-spec>`_.
+
+.. warning::
+
+  - Vector MBTiles (with data in `Mapbox Vector Tile format (pbf) <https://github.com/mapbox/vector-tile-spec>`_) are only supported if :guilabel:`Mapbox` is selected as the :ref:`basemap source <basemap-settings>`.
+
+  - Vector MBTiles are currently displayed without styling. Each layer's lines are displayed in a different color picked by ODK Collect. This color will be the same across all devices using the same MBTiles file. Fills are not displayed.
 
 .. _offline-maps-quick-start:
 
 Offline maps quick start
 -------------------------
-#. From :ref:`Collect's settings <mapping-settings>`, change the Mapping SDK to Google Maps SDK
 #. :ref:`Get or create your MBTiles file <getting-map-tiles>` with `TileMill <https://tilemill-project.github.io/tilemill/>`_ or other software.
-#. :ref:`Transfer tiles to devices <transferring-offline-tiles>`. The MBTiles file must be placed in a sub-folder on your device in the :file:`/sdcard/odk/layers` folder.
-#. Open a :ref:`question that displays a map <location-widgets>`.
-#. Tap the layers icon and select your map
+#. :ref:`Transfer tiles to devices <transferring-offline-tiles>`. The MBTiles file must be placed on your device in the :file:`/sdcard/odk/layers` folder.
+#. Select your offline layer in the :ref:`reference layer settings <reference-layer-settings>`.
+#. Open a :ref:`geopoint <geopoint-maps>`, :ref:`geotrace <geotrace-widget>`, or :ref:`geoshape <geoshape-widget>` questions.
+
+Your offline layer should be displayed. If it has transparency (PNG or PBF tiles only), the selected basemap will show through. If it does not have transparency or you are offline, only your offline layer will be displayed.
 
 .. _getting-map-tiles:
 
-Getting map tiles
+Getting map tilesets
 -------------------------
-`Open Map Tiles <https://openmaptiles.org/>`_ hosts many free map tile files that can be used in ODK Collect.
+`OpenMapTiles <https://openmaptiles.org/>`_ hosts many free map tile files that can be used in Collect.
 
-To create MBTiles files, use one of the `compatible applications <https://github.com/mapbox/mbtiles-spec/wiki/Implementations#applications>`_ that can write tiles. Commonly used free software packages are `TileMill <https://tilemill-project.github.io/tilemill/>`_ and `QGIS <https://qgis.org/en/site/>`_ with the `QTiles plugin <https://github.com/nextgis/QTiles#qtiles>`_.
+To create MBTiles files, use one of the `compatible applications <https://github.com/mapbox/mbtiles-spec/wiki/Implementations#applications>`_ . Commonly used free software packages are `TileMill <https://tilemill-project.github.io/tilemill/>`_ and `QGIS <https://qgis.org/en/site/>`_ with the `QTiles plugin <https://github.com/nextgis/QTiles#qtiles>`_.
 
+If you have existing geospatial data that is not in an MBTiles file, you may be able to convert it for use in Collect. For example, `Tippecanoe <https://github.com/mapbox/tippecanoe>`_ is a tool to build vector MBTiles files from GeoJSON features (see warning above: vector MBTiles files are only supported with Mapbox basemaps and are displayed without styling).
+
+The name of the tileset provided in the MBTiles file will be displayed in the Collect layer selection menu. The filename will also be displayed.
 
 .. _transferring-offline-tiles:
 
-Transferring offline tiles to devices
--------------------------------------
-To make MBTiles files available for use in ODK Collect they must be manually transferred to Android devices. The tile files need to be inside a folder in the :file:`/sdcard/odk/layers` folder. The folder name will be used to identify your offline map in the user interface so choose a user-friendly name for it. For example, if your MBTiles file is `my_tiles.mbtiles` and it includes information about settlements in the mapped area, you may want to call your folder :file:`/sdcard/odk/layers/All settlements/`.
+Transferring offline tilesets to devices
+-----------------------------------------
+MBTiles files must be manually transferred to Android devices to be available to Collect. Place the MBTiles files in the :file:`/sdcard/odk/layers` folder.
 
-.. note::
+To transfer files, you can upload them to an online service such as Google Drive, connect your device to a computer and transfer them via USB, or use :doc:`adb <collect-adb>`.
 
-  MBTiles files placed directly in the :file:`/sdcard/odk/layers` folder will not be detected! Placing it in a subdirectory with a friendly name is required.
+.. _selecting-offline-tilesets:
 
-To transfer files, you can upload them to an online service such as Google Drive, connect your device to a computer and transfer them via USB or use :doc:`adb <collect-adb>`.
+Selecting offline tilesets
+---------------------------
+Once an MBTiles file has been transfered to the :file:`/sdcard/odk/layers` folder, it will be available for selection as a reference layer. A reference layer provides useful reference information for a data collector. A reference layer with no transparency acts like a basemap.
+
+There are two ways to set the reference layer:
+
+- from :ref:`mapping-settings`
+- by tapping on the layers button in a :ref:`geopoint <geopoint-maps>`, :ref:`geotrace <geotrace-widget>`, or :ref:`geoshape <geoshape-widget>` question
+
+Both options set the reference layer for all :ref:`geopoint <geopoint-maps>`, :ref:`geotrace <geotrace-widget>`, and :ref:`geoshape <geoshape-widget>` questions. The tileset name shown in the menu is read from the metadata in the MBTiles file.

--- a/odk1-src/collect-offline-maps.rst
+++ b/odk1-src/collect-offline-maps.rst
@@ -13,9 +13,12 @@
 Using Offline Maps
 ====================
 
-Collect's :ref:`geopoint <geopoint-maps>`, :ref:`geotrace <geotrace-widget>`, and :ref:`geoshape <geoshape-widget>` questions can be configured to display different map data. To use online basemaps, :ref:`set the basemap source and style <basemap-settings>` in :guilabel:`mapping-settings`. Users will need to be online to load questions with maps.
+Collect's :ref:`geopoint <geopoint-maps>`, :ref:`geotrace <geotrace-widget>`, and :ref:`geoshape <geoshape-widget>` questions can be configured to display different map data. The :ref:`mapping-settings` let you select a basemap to show, as well as a reference
+layer to show on top of the basemap.
 
-Offline layers are useful to present custom geospatial data layered over standard basemaps or as basemaps for low-connectivity environments. Use them to display high-resolution imagery, annotated maps, heatmaps, and more. ODK Collect can display any map layer saved as a set of tiles in the `MBTiles format <https://github.com/mapbox/mbtiles-spec>`_.
+The data for all the available basemaps comes from services on the Internet, so the basemap will only be visible to users who are online. To choose a basemap, select a :guilabel:`Source` and then a :guilabel:`Style` if multiple styles are available.
+
+For the reference layer, however, you can select a file on the device, and it will be visible offline. Offline layers are useful to present custom geospatial data layered over standard basemaps or as basemaps for low-connectivity environments. Use them to display high-resolution imagery, annotated maps, heatmaps, and more. ODK Collect can display any map layer saved as a set of tiles in the `MBTiles format <https://github.com/mapbox/mbtiles-spec>`_.
 
 .. warning::
 
@@ -28,11 +31,14 @@ Offline layers are useful to present custom geospatial data layered over standar
 Offline maps quick start
 -------------------------
 #. :ref:`Get or create your MBTiles file <getting-map-tiles>` with `TileMill <https://tilemill-project.github.io/tilemill/>`_ or other software.
-#. :ref:`Transfer tiles to devices <transferring-offline-tiles>`. The MBTiles file must be placed on your device in the :file:`/sdcard/odk/layers` folder.
+#. :ref:`Transfer tiles to devices <transferring-offline-tiles>`. The MBTiles file must be placed on your device in the :file:`/sdcard/odk/layers` folder, and the filename must end in `.mbtiles`.
 #. Select your offline layer in the :ref:`reference layer settings <reference-layer-settings>`.
-#. Open a :ref:`geopoint <geopoint-maps>`, :ref:`geotrace <geotrace-widget>`, or :ref:`geoshape <geoshape-widget>` questions.
+#. Open a :ref:`geopoint <geopoint-maps>`, :ref:`geotrace <geotrace-widget>`, or :ref:`geoshape <geoshape-widget>` question.
+#. While viewing the map, you can also select the offline layer using the button that looks like a stack of layers.
 
-Your offline layer should be displayed. If it has transparency (PNG or PBF tiles only), the selected basemap will show through. If it does not have transparency or you are offline, only your offline layer will be displayed.
+MBTiles files typically contain `metadata <https://github.com/mapbox/mbtiles-spec/blob/master/1.3/spec.md#metadata>` that specifies the range of zoom levels in which they are visible.  If you are viewing at an appropriate zoom level, your offline layer should be displayed. If you don't see it, you might need to zoom in or out until the zoom level is in the range specified by the MBTiles file.
+
+If the tileset has transparency (PNG or PBF tiles only), the selected basemap will show through. If it does not have transparency or you are offline, only your offline layer will be displayed.
 
 .. _getting-map-tiles:
 
@@ -44,13 +50,11 @@ To create MBTiles files, use one of the `compatible applications <https://github
 
 If you have existing geospatial data that is not in an MBTiles file, you may be able to convert it for use in Collect. For example, `Tippecanoe <https://github.com/mapbox/tippecanoe>`_ is a tool to build vector MBTiles files from GeoJSON features (see warning above: vector MBTiles files are only supported with Mapbox basemaps and are displayed without styling).
 
-The name of the tileset provided in the MBTiles file will be displayed in the Collect layer selection menu. The filename will also be displayed.
-
 .. _transferring-offline-tiles:
 
 Transferring offline tilesets to devices
 -----------------------------------------
-MBTiles files must be manually transferred to Android devices to be available to Collect. Place the MBTiles files in the :file:`/sdcard/odk/layers` folder.
+MBTiles files must be manually transferred to Android devices to be available to Collect. Place the MBTiles files in the :file:`/sdcard/odk/layers` folder, and ensure their filenames end in `.mbtiles`.
 
 To transfer files, you can upload them to an online service such as Google Drive, connect your device to a computer and transfer them via USB, or use :doc:`adb <collect-adb>`.
 
@@ -58,11 +62,11 @@ To transfer files, you can upload them to an online service such as Google Drive
 
 Selecting offline tilesets
 ---------------------------
-Once an MBTiles file has been transfered to the :file:`/sdcard/odk/layers` folder, it will be available for selection as a reference layer. A reference layer provides useful reference information for a data collector. A reference layer with no transparency acts like a basemap.
+Once an MBTiles file has been transferred to the :file:`/sdcard/odk/layers` folder, it will be available for selection as a reference layer. A reference layer provides useful reference information for a data collector. A reference layer with no transparency acts like a basemap.
 
 There are two ways to set the reference layer:
 
 - from :ref:`mapping-settings`
-- by tapping on the layers button in a :ref:`geopoint <geopoint-maps>`, :ref:`geotrace <geotrace-widget>`, or :ref:`geoshape <geoshape-widget>` question
+- by tapping on the button that looks in a stack of layers in a :ref:`geopoint <geopoint-maps>`, :ref:`geotrace <geotrace-widget>`, or :ref:`geoshape <geoshape-widget>` question
 
-Both options set the reference layer for all :ref:`geopoint <geopoint-maps>`, :ref:`geotrace <geotrace-widget>`, and :ref:`geoshape <geoshape-widget>` questions. The tileset name shown in the menu is read from the metadata in the MBTiles file.
+Both options set the reference layer for all :ref:`geopoint <geopoint-maps>`, :ref:`geotrace <geotrace-widget>`, and :ref:`geoshape <geoshape-widget>` questions. The choices in the Collect layer selection menu will show the name of the tileset (from the `Metadata table in the MBTiles file <https://github.com/mapbox/mbtiles-spec/blob/master/1.3/spec.md#metadata>`_), as well as the path to the file.

--- a/odk1-src/collect-settings.rst
+++ b/odk1-src/collect-settings.rst
@@ -1,3 +1,10 @@
+.. spelling:: 
+  basemap
+  Basemap
+  basemaps
+  Basemaps
+  Mapbox
+
 Collect Menus, Settings, and Security
 =====================================
 
@@ -148,7 +155,7 @@ Basemap settings configure the background of maps shown by the :ref:`location qu
 
 Reference layer settings
 """""""""""""""""""""""""
-Reference layer settings configure map data shown on top of the basemap. Currently, a reference layer can only be defined by an offline MBtiles file as described in :doc:`collect-offline-maps`. If a reference layer has no transparency, it will fully cover the basemap selected above and behave like an offline basemap. Vector MBTiles files will only be available in the :guilabel:`Layer data file` menu if a Mapbox basemap is selected. Raster MBTiles files will be available for any basemap source and style.
+Reference layer settings configure map data shown on top of the basemap. Currently, a reference layer can only be defined by an offline MBTiles file as described in :doc:`collect-offline-maps`. If a reference layer has no transparency, it will fully cover the basemap selected above and behave like an offline basemap. Vector MBTiles files will only be available in the :guilabel:`Layer data file` menu if a Mapbox basemap is selected. Raster MBTiles files will be available for any basemap source and style.
 
 .. _form-management-settings:
 

--- a/odk1-src/collect-settings.rst
+++ b/odk1-src/collect-settings.rst
@@ -116,23 +116,39 @@ To access User Interface settings:
 
 .. _mapping-settings:
 
-.. rubric:: Mapping
+Maps Settings
+~~~~~~~~~~~~~~~
 
-:guilabel:`Mapping SDK` 
-  Sets the mapping engine that will be used for 
-  form question types that require map integration.
+Maps settings configure the maps shown by the :ref:`location question types <location-widgets>`.
+
+To access Maps settings:
+  :menuselection:`⋮ --> General Settings --> Maps` 
+
+.. note::
+
+  Prior to ODK Collect v1.23, map settings were available in the :ref:`interface-settings`. The basemap was configured by first selecting a :guilabel:`Mapping SDK` and then a :guilabel:`Basemap`.
+
+.. _basemap-settings:
+
+Basemap settings
+""""""""""""""""""
+Basemap settings configure the background of maps shown by the :ref:`location question types <location-widgets>`. Basemaps are provided by several different :guilabel:`Sources` which may each make several different map :guilabel:`Styles` available. A basemap is intended to provide details that help users orient a map and to make the map easy to use in a particular data collection environment. For example, if the data to be collected relates to elevation, consider selecting a topographic basemap.
   
-  Options:
-  
-  - Google Maps (default)
-  - OpenStreetMap
- 
-  .. seealso:: :ref:`geopoint-widget`, :ref:`geoshape-widget`, :ref:`geotrace-widget`, :doc:`offline maps <collect-offline-maps>`
-  
-  
-:guilabel:`Basemap` 
-  Sets the map to be displayed 
-  when a question with a mapping component is opened.
+:guilabel:`Sources` 
+  A basemap source provides one or more map styles:
+
+  - :guilabel:`Google` basemap styles are used by Google Maps and other Google products.
+  - :guilabel:`Mapbox` basemap styles are `used in many familiar products <https://www.mapbox.com/maps/streets/>`_.
+  - :guilabel:`OpenStreetMap` provides one style which also powers `openstreetmap.org <https://www.openstreetmap.org>`_. OpenStreetMap data is used in basemaps provided by all other sources as well.
+  - :guilabel:`USGS` is the United States Geological Survey. It provides `topograpic and satellite basemaps <https://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer>`_ for the United States only.
+  - :guilabel:`Stamen` provides `a terrain basemap with large labels <http://maps.stamen.com/terrain>`_.
+  - :guilabel:`Carto` basemap styles are `designed to be used with data layers <https://carto.com/blog/getting-to-know-positron-and-dark-matter/>`_.
+
+  .. _reference-layer-settings:
+
+Reference layer settings
+"""""""""""""""""""""""""
+Reference layer settings configure map data shown on top of the basemap. Currently, a reference layer can only be defined by an offline MBtiles file as described in :doc:`collect-offline-maps`. If a reference layer has no transparency, it will fully cover the basemap selected above and behave like an offline basemap. Vector MBTiles files will only be available in the :guilabel:`Layer data file` menu if a Mapbox basemap is selected. Raster MBTiles files will be available for any basemap source and style.
 
 .. _form-management-settings:
 

--- a/odk1-src/collect-settings.rst
+++ b/odk1-src/collect-settings.rst
@@ -155,7 +155,7 @@ Basemap settings configure the background of maps shown by the :ref:`location qu
 
 Reference layer settings
 """""""""""""""""""""""""
-Reference layer settings configure map data shown on top of the basemap. Currently, a reference layer can only be defined by an offline MBTiles file as described in :doc:`collect-offline-maps`. If a reference layer has no transparency, it will fully cover the basemap selected above and behave like an offline basemap. Vector MBTiles files will only be available in the :guilabel:`Layer data file` menu if a Mapbox basemap is selected. Raster MBTiles files will be available for any basemap source and style.
+Reference layer settings configure map data shown on top of the basemap. Currently, a reference layer can only be defined by an offline MBTiles file as described in :doc:`collect-offline-maps`. The reference layer will appear when the zoom level is within the range supported by the file. If a reference layer has no transparency, it will fully cover the basemap selected above and behave like an offline basemap. Vector MBTiles files will only be available in the :guilabel:`Layer data file` menu if a Mapbox basemap is selected. Raster MBTiles files will be available for any basemap source and style.
 
 .. _form-management-settings:
 


### PR DESCRIPTION
closes #1073

Updates map settings and offline maps sections to match Collect v1.23. I tried to give a little help for folks on older versions.

I didn't add any screenshots because I don't think they are necessary. Let me know if you think otherwise. I considered adding an image for the layers button, though. Would that be helpful? I'm guessing folks who have the capacity to use offline tiles have seen gis software before and will recognize the layers icon but could be convinced otherwise.

I didn't go into too much detail about offline vector tilesets because we hope to improve that soon.

There's a bit of redundancy because I was trying to make each section stand alone. If this is bothersome, I can revisit.

I ran `make odk1-spell-check` locally and verified there were no spelling errors in the new files.

CC @zestyping and @yanokwa 