### PR TITLE
Use JDK 11 because JDK 8 is no longer supported

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
           name: Install deploy requirements
           command: |
               if [[ "$CIRCLE_PROJECT_USERNAME" == "opendatakit" ]]; then \
-                sudo apt-get install -y openjdk-8-jre-headless
+                sudo apt-get install -y openjdk-11-jre-headless
                 gem install s3_website && s3_website install
               fi
       - run:
@@ -171,7 +171,7 @@ jobs:
           name: Install deploy requirements
           command: |
               if [[ "$CIRCLE_PROJECT_USERNAME" == "opendatakit" ]]; then \
-                sudo apt-get install -y openjdk-8-jre-headless
+                sudo apt-get install -y openjdk-11-jre-headless
                 gem install s3_website && s3_website install
               fi
       - run:
@@ -191,7 +191,7 @@ jobs:
           name: Install deploy requirements
           command: |
               if [[ "$CIRCLE_PROJECT_USERNAME" == "opendatakit" ]]; then \
-                sudo apt-get install -y openjdk-8-jre-headless
+                sudo apt-get install -y openjdk-11-jre-headless
                 gem install s3_website && s3_website install
               fi
       - run:


### PR DESCRIPTION
<!-- ALL PRs MUST BE RELATED TO AN OPEN ISSUE -->
closes #1085

I did a search and replace for `openjdk-8-jre-headless` to `openjdk-11-jre-headless`. I don't think there's a great way of verifying this other than merging and having it run on CircleCI.