### PR TITLE
Clarify ex:prefix use

### DIFF
--- a/odk1-src/launch-apps-from-collect.rst
+++ b/odk1-src/launch-apps-from-collect.rst
@@ -54,7 +54,7 @@ In the examples above, the extras specified have names ``form_id``, ``form_name`
 Launching external apps to populate multiple fields
 -------------------------------------------------------
 
-Since v1.4.3, a ``field-list`` group can have an ``intent`` attribute that allows an external application to populate it. 
+Since v1.4.3, a ``field-list`` group can have an ``intent`` attribute that allows an external application to populate it. Notice that the ex:prefix is not included.
 
 XLSForm
 ~~~~~~~~~

--- a/odk1-src/launch-apps-from-collect.rst
+++ b/odk1-src/launch-apps-from-collect.rst
@@ -54,7 +54,7 @@ In the examples above, the extras specified have names ``form_id``, ``form_name`
 Launching external apps to populate multiple fields
 -------------------------------------------------------
 
-Since v1.4.3, a ``field-list`` group can have an ``intent`` attribute that allows an external application to populate it. Notice that the ex:prefix is not included.
+Since v1.4.3, a ``field-list`` group can have an ``intent`` attribute that allows an external application to populate it. Notice that the ``ex:`` prefix used when populating a single field is not included to populate multiple fields.
 
 XLSForm
 ~~~~~~~~~


### PR DESCRIPTION
Add text "Notice that the ex:prefix is not included" to Clarify that ex: prefix is only for external apps that populate one field.

<!-- ALL PRs MUST BE RELATED TO AN OPEN ISSUE -->
closes #
<!-- OR -->
addresses #


#### What is included in this PR?



<!-- Answer any that apply and delete the others. -->
#### What new issues will need to be opened because of this PR?

#### What is left to be done in the addressed issue?

#### What problems did you encounter?
