### PR TITLE
Warn that changing audit log options for a form definition and then editing an existing record can result in a corrupt audit

### DIFF
--- a/odk1-src/form-audit-log.rst
+++ b/odk1-src/form-audit-log.rst
@@ -229,4 +229,6 @@ When the cell is set to type :th:`date time` in common spreadsheet programs, it 
 Known limitations
 -------------------
 
-If the device is turned off while a form is being filled, Collect will not record a log entry for the screen that was shown at the time of device shutdown. Events before and after the shutdown will be logged.
+- If the device is turned off while a form is being filled, Collect will not record a log entry for the screen that was shown at the time of device shutdown. Events before and after the shutdown will be logged.
+
+- Editing a saved form that was saved using different audit log options can result in a corrupt audit. It might take place when a user saves a form then updates a form definition (changing audit log options) and tries to edit the saved form.


### PR DESCRIPTION
closes #1054 

#### What is included in this PR?
It documents that changing audit log options for a form definition and then editing an existing record can result in a corrupt audit.