### PR TITLE
Logic within a field list is evaluated in Collect v1.22+

### DIFF
--- a/odk1-src/form-logic.rst
+++ b/odk1-src/form-logic.rst
@@ -22,6 +22,10 @@ in your `XLSForm`_ definition.
 
 .. _XLSForm: http://xlsform.org/
 
+.. warning::
+
+  Relevance, constraint and calculation evaluation :ref:`within the same screen <field-list>` is supported in Collect v1.22 and later. In earlier versions of Collect, questions tied by logic must be displayed on different screens.
+
 .. contents:: :depth: 2
  :local:
 

--- a/odk1-src/form-question-types.rst
+++ b/odk1-src/form-question-types.rst
@@ -2249,16 +2249,7 @@ The :tc:`field-list` appearance attribute, applied to a group of widgets, displa
 
 .. warning::
 
-  Do not include a question that depends on a previous answer
-  in the same field list as the previous question it depends on.
-
-  Relevance and calculation values are determined
-  when the screen advances,
-  which does not happen between questions
-  that are grouped on the same page.
-  Therefore,
-  including a question and its dependent together in a field list
-  will not work as expected.
+  Relevance, constraint and calculation evaluation within the same screen is supported in Collect v1.22 and later.
 
 .. seealso::
 


### PR DESCRIPTION
Begins addressing #1016

How to frame the current limitations with `once` requires some thought but I want to make sure that it's clear that newer versions of Collect do support logic evaluation within a screen.