### PR TITLE
Clean up repeats section and add recipes for avoiding dialog

### DIFF
--- a/odk1-src/form-logic.rst
+++ b/odk1-src/form-logic.rst
@@ -536,7 +536,7 @@ You can ask the same question or questions multiple times by wrapping them in :t
 .. csv-table:: survey
   :header: type, name, label 
 
-  begin_repeat, my_repeat, Repeat label
+  begin_repeat, my_repeat, repeat group label
   note, repeated_note, All of these questions will be repeated.
   text, name, What is your name?
   text, quest, What is your quest?

--- a/odk1-src/form-logic.rst
+++ b/odk1-src/form-logic.rst
@@ -514,8 +514,12 @@ Groups without labels can be helpful for organizing questions in a way that's in
 
 .. _repeats:
 
-Repeating groups of questions
-=============================
+Repeating questions
+=====================
+You can ask the same question or questions multiple times by wrapping them in :tc:`begin_repeat...end_repeat`. By default, enumerators are asked before each repetition whether they would like to add another repeat. It is also possible to :ref:`determine the number of repetitions ahead of time <statically-defined-repeats>` which can make the user interaction more intuitive.
+
+.. seealso::
+    :doc:`form-repeats` describes strategies to address common repetition scenarios.
 
 .. note::
   Using repetition in a form is very powerful but can also make training and data analysis more time-consuming. Aggregate does not export repeats so Briefcase or one of the data publishers will be needed to :doc:`transfer data from Aggregate <aggregate-data-access>`. Repeats will be in their own documents and will need to be joined with their parent records for analysis.
@@ -527,25 +531,13 @@ Repeating groups of questions
 
   If repeats are needed, consider adding some summary calculations at the end so that analysis will not require joining the repeats with their parent records. For example, if you are gathering household information and would like to compute the total number of households visited across all enumerators, add a calculation after the repeats that counts the repetitions in each submission.
 
-To repeat questions or groups of questions
-use the :tc:`begin_repeat...end_repeat` syntax.
-
-.. rubric:: XLSForm --- Single question repeat group
+.. rubric:: XLSForm --- Repeating one or more questions
 
 .. csv-table:: survey
   :header: type, name, label 
 
-  begin_repeat, my_repeat_group, Repeat group label
-  text, repeated_question, This question will be repeated.
-  end_repeat, , 
-
-.. rubric:: XLSForm --- Multi-question repeat group
-
-.. csv-table:: survey
-  :header: type, name, label 
-
-  begin_repeat, my_repeat, Repeat group label
-  note, repeated_note, These questions will be repeated as an entire group.
+  begin_repeat, my_repeat, Repeat label
+  note, repeated_note, All of these questions will be repeated.
   text, name, What is your name?
   text, quest, What is your quest?
   text, fave_color, What is your favorite color?
@@ -562,12 +554,9 @@ Controlling the number of repetitions
 User-controlled repeats
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default,
-the user controls how many times 
-the questions are repeated.
+By default, the enumerator controls how many times the questions are repeated.
 
-Before each repetition,
-the user is asked if they want to add another repeat group.
+Before each repetition, the user is asked if they want to add another.
 
 .. note::
 
@@ -580,32 +569,22 @@ the user is asked if they want to add another repeat group.
 .. figure:: /img/form-logic/repeat-iteration-modal.* 
   :alt: The Collect app. A modal dialog labeled "Add new group?" with the question: "Add a new 'repeat group label' group?" and options "Do not add" and "Add Group".
   
-  The user is given the option to add each iteration.
-
-.. rubric:: XLSForm
-
-.. csv-table:: survey
-  :header: type, name, label
-  
-  begin_repeat, repeat_example, repeat group label
-  text, repeat_test, Question label
-  end_repeat,,
+  The user is given the option to add each repetition.
 
 .. note::
 
-  This interaction may be confusing to users the first time they see it. If enumerators know the number of repetitions ahead of time, consider using :ref:`dynamically defined repeats <dynamically-defined-repeats>`.
+  This interaction may be confusing to users the first time they see it. If enumerators know the number of repetitions ahead of time, consider using a :ref:`dynamically defined repeat count <dynamically-defined-repeats>`.
 
 .. tip::
 
-  The :ref:`jump <jumping>` menu also provides shortcuts to :ref:`add <adding_repeats>` or :ref:`remove <removing_repeats>` instances of repeating groups.
+  The :ref:`jump <jumping>` menu also provides shortcuts to :ref:`add <adding_repeats>` or :ref:`remove <removing_repeats>` repeat instances.
 
 .. _statically-defined-repeats:
 
-Statically defined repeats
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Fixed repeat count
+~~~~~~~~~~~~~~~~~~~~
 
-Use the :th:`repeat_count` column
-to define the number of times a group will repeat.
+Use the :th:`repeat_count` column to define the number of times that questions will repeat.
 
 
 .. rubric:: XLSForm
@@ -614,7 +593,7 @@ to define the number of times a group will repeat.
   :header: type, name, label, repeat_count
 
   begin_repeat, my_repeat, Repeat group label, 3
-  note, repeated_note, These questions will be repeated as an entire group.
+  note, repeated_note, These questions will be repeated exactly three times.
   text, name, What is your name?
   text, quest, What is your quest?
   text, fave_color, What is your favorite color?
@@ -622,11 +601,10 @@ to define the number of times a group will repeat.
  
 .. _dynamically-defined-repeats:
  
-Dynamically defined repeats
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Dynamically defined repeat count
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The :th:`repeat_count` column can reference
-:ref:`previous responses <variables>` and :ref:`calculations <calculations>`.
+The :th:`repeat_count` column can reference :ref:`previous responses <variables>` and :ref:`calculations <calculations>`.
 
 .. rubric:: XLSForm
 
@@ -638,9 +616,6 @@ The :th:`repeat_count` column can reference
   text, child_name, Child's name,
   integer, child_age, Child's age,
   end_repeat, , , 
-
-
-.. seealso:: :doc:`form-repeats`
   
 .. _cascading-selects:
   

--- a/odk1-src/form-logic.rst
+++ b/odk1-src/form-logic.rst
@@ -518,19 +518,6 @@ Repeating questions
 =====================
 You can ask the same question or questions multiple times by wrapping them in :tc:`begin_repeat...end_repeat`. By default, enumerators are asked before each repetition whether they would like to add another repeat. It is also possible to :ref:`determine the number of repetitions ahead of time <statically-defined-repeats>` which can make the user interaction more intuitive. You can also :ref:`add repeats as long as a condition is met <repeat_based_on_condition>`.
 
-.. seealso::
-    :doc:`form-repeats` describes strategies to address common repetition scenarios.
-
-.. note::
-  Using repetition in a form is very powerful but can also make training and data analysis more time-consuming. Aggregate does not export repeats so Briefcase or one of the data publishers will be needed to :doc:`transfer data from Aggregate <aggregate-data-access>`. Repeats will be in their own documents and will need to be joined with their parent records for analysis.
-  
-  Before adding repeats to your form, consider other options:
-
-  - if the number of repetitions is small and known ahead of time, consider "unrolling" the repeat by copying the same questions several times.
-  - if the number of repetitions is large and includes many questions, consider building a separate form that enumerators fill out multiple times and link the forms with some parent key (e.g., a household ID).
-
-  If repeats are needed, consider adding some summary calculations at the end so that analysis will not require joining the repeats with their parent records. For example, if you are gathering household information and would like to compute the total number of households visited across all enumerators, add a calculation after the repeats that counts the repetitions in each submission.
-
 .. rubric:: XLSForm --- Repeating one or more questions
 
 .. csv-table:: survey
@@ -542,6 +529,19 @@ You can ask the same question or questions multiple times by wrapping them in :t
   text, quest, What is your quest?
   text, fave_color, What is your favorite color?
   end_repeat, , 
+
+.. seealso::
+    :doc:`form-repeats` describes strategies to address common repetition scenarios.
+
+.. tip::
+  Using repetition in a form is very powerful but can also make training and data analysis more time-consuming. Aggregate does not export repeats so Briefcase or one of the data publishers will be needed to :doc:`transfer data from Aggregate <aggregate-data-access>`. Repeats will be in their own documents and will need to be joined with their parent records for analysis.
+
+  Before adding repeats to your form, consider other options:
+
+  - if the number of repetitions is small and known ahead of time, consider "unrolling" the repeat by copying the same questions several times.
+  - if the number of repetitions is large and includes many questions, consider building a separate form that enumerators fill out multiple times and link the forms with some parent key (e.g., a household ID).
+
+  If repeats are needed, consider adding some summary calculations at the end so that analysis will not require joining the repeats with their parent records. For example, if you are gathering household information and would like to compute the total number of households visited across all enumerators, add a calculation after the repeats that counts the repetitions in each submission.
  
   
 .. _controlling-number-of-repeats:
@@ -566,14 +566,12 @@ Before each repetition, the user is asked if they want to add another.
   A meaningful label will help enumerators and participants 
   navigate the form as intended.
 
+  This interaction may be confusing to users the first time they see it. If enumerators know the number of repetitions ahead of time, consider using a :ref:`dynamically defined repeat count <dynamically-defined-repeats>`.
+
 .. figure:: /img/form-logic/repeat-iteration-modal.* 
   :alt: The Collect app. A modal dialog labeled "Add new group?" with the question: "Add a new 'repeat group label' group?" and options "Do not add" and "Add Group".
   
   The user is given the option to add each repetition.
-
-.. note::
-
-  This interaction may be confusing to users the first time they see it. If enumerators know the number of repetitions ahead of time, consider using a :ref:`dynamically defined repeat count <dynamically-defined-repeats>`.
 
 .. tip::
 
@@ -646,8 +644,8 @@ In the `repeat_count` expression, `${count} = 0` ensures that there is always at
 
 .. _zero-repetitions:
 
-Representing zero or more repetitions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Repeating zero or more times
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Sometimes it only makes sense to collect information represented by the questions in a repeat under certain conditions. If the number of total repetitions is known ahead of time, use :ref:`dynamically-defined-repeats` and allow a count of 0. If the count is not known ahead of time, :ref:`relevants` can be used to represent 0 or more repetitions. In the example below, questions about trees will only be asked if the user indicates that there are trees to survey.
 

--- a/odk1-src/form-logic.rst
+++ b/odk1-src/form-logic.rst
@@ -516,7 +516,7 @@ Groups without labels can be helpful for organizing questions in a way that's in
 
 Repeating questions
 =====================
-You can ask the same question or questions multiple times by wrapping them in :tc:`begin_repeat...end_repeat`. By default, enumerators are asked before each repetition whether they would like to add another repeat. It is also possible to :ref:`determine the number of repetitions ahead of time <statically-defined-repeats>` which can make the user interaction more intuitive.
+You can ask the same question or questions multiple times by wrapping them in :tc:`begin_repeat...end_repeat`. By default, enumerators are asked before each repetition whether they would like to add another repeat. It is also possible to :ref:`determine the number of repetitions ahead of time <statically-defined-repeats>` which can make the user interaction more intuitive. You can also :ref:`add repeats as long as a condition is met <repeat_based_on_condition>`.
 
 .. seealso::
     :doc:`form-repeats` describes strategies to address common repetition scenarios.
@@ -616,6 +616,33 @@ The :th:`repeat_count` column can reference :ref:`previous responses <variables>
   text, child_name, Child's name,
   integer, child_age, Child's age,
   end_repeat, , , 
+
+.. _repeat_based_on_condition:
+
+Repeating as long as a condition is met
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the enumerator won't know how many repetitions are needed ahead of time, you can still avoid the "Add new group?" dialog by using the answer to a question to decide whether another repeat instance should be added. In the example below, repeated questions about plants will be asked as long as the user answers "yes" to the last question.
+
+.. csv-table:: survey
+  :header: type, name, label, calculation, repeat_count
+  
+  calculate, count, , count(${plant})
+  begin_repeat, plant, Plant, , if(${count} = 0 or ${plant}[position()=${count}]/more_plants = 'yes', ${count} + 1, ${count})
+  text, species, Species,
+  integer, estimated_size, Estimated size,
+  select_one yes_no, more_plants, Are there more plants in this area?,
+  end_repeat, , , ,
+
+.. csv-table:: choices
+  :header: list_name, name, label
+  
+  yes_no, yes, Yes
+  yes_no, no, No
+
+This works by maintaining a :func:`count` of the existing repetitions and either making :th:`repeat_count` one more than that if the continuing condition is met or keeping the :th:`repeat_count` the same if the ending condition is met. 
+
+In the `repeat_count` expression, `${count} = 0` ensures that there is always at least one repeat instance created. The continuing condition is `${plant}[position()=${count}]/more_plants = 'yes'` which means "the answer to `more_plants` was `yes` the last time it was asked." The expression `position()=${count}` uses the :func:`position` function to select the last plant that was added. Adding `/more_plants` to the end of that selects the `more_plants` question.
 
 .. _zero-repetitions:
 

--- a/odk1-src/form-logic.rst
+++ b/odk1-src/form-logic.rst
@@ -598,7 +598,7 @@ Use the :th:`repeat_count` column to define the number of times that questions w
   text, quest, What is your quest?
   text, fave_color, What is your favorite color?
   end_repeat, , 
- 
+
 .. _dynamically-defined-repeats:
  
 Dynamically defined repeat count
@@ -616,7 +616,29 @@ The :th:`repeat_count` column can reference :ref:`previous responses <variables>
   text, child_name, Child's name,
   integer, child_age, Child's age,
   end_repeat, , , 
+
+.. _zero-repetitions:
+
+Representing zero or more repetitions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes it only makes sense to collect information represented by the questions in a repeat under certain conditions. If the number of total repetitions is known ahead of time, use :ref:`dynamically-defined-repeats` and allow a count of 0. If the count is not known ahead of time, :ref:`relevants` can be used to represent 0 or more repetitions. In the example below, questions about trees will only be asked if the user indicates that there are trees to survey.
+
+.. csv-table:: survey
+  :header: type, name, label, relevant
   
+  select_one yes_no, trees_present, Are there any trees in this area?,
+  begin_repeat, tree, Tree, ${trees_present} = 'yes'
+  text, species, Species,
+  integer, estimated_age, Estimated age,
+  end_repeat, , , ,
+
+.. csv-table:: choices
+  :header: list_name, name, label
+  
+  yes_no, yes, Yes
+  yes_no, no, No
+
 .. _cascading-selects:
   
 Filtering options in select questions

--- a/odk1-src/form-operators-functions.rst
+++ b/odk1-src/form-operators-functions.rst
@@ -165,7 +165,7 @@ Control flow
   
   .. container:: details
   
-    .. include:: incl/form-examples/parallel-repeat-groups.rst
+    .. include:: incl/form-examples/parallel-repeats.rst
 
 .. function:: once(expression)
 
@@ -372,7 +372,7 @@ Repeat groups
 
   .. container:: details
   
-    .. include:: incl/form-examples/parallel-repeat-groups.rst
+    .. include:: incl/form-examples/parallel-repeats.rst
 
 .. function:: count(nodeset)
 
@@ -380,7 +380,7 @@ Repeat groups
 
   .. container:: details
   
-    .. include:: incl/form-examples/parallel-repeat-groups.rst
+    .. include:: incl/form-examples/parallel-repeats.rst
   
 .. function:: count-non-empty(nodeset)
 

--- a/odk1-src/form-repeats.rst
+++ b/odk1-src/form-repeats.rst
@@ -15,6 +15,76 @@ Repeat Recipes and Tips
 .. contents:: :depth: 2
  :local:
 
+.. _referencing-answers-in-repeats:
+
+Referencing repeated questions from inside the repeat
+-----------------------------------------------------
+
+Within a repeat, you can reference other questions **in that same repeat instance** :ref:`in the usual manner <variables>`.
+
+.. rubric:: XLSForm
+
+.. csv-table:: survey
+  :header: type, name, label
+
+  note, child_questions_note, Please provide the following details about each child in your household.
+  begin_repeat, child_details, Children in household
+  text, child_first_name, Name
+  text, child_age, Age of ${child_first_name}
+  end_repeat
+
+To reference a question from a different repeat instance, or from outside the repeat, use :func:`indexed-repeat` and :func:`position`.
+ 
+.. _referencing-responses-from-outside-repeat-loop:
+  
+Referencing repeated questions from outside the repeat
+-------------------------------------------------------
+
+A question in a repeat can be referenced from outside the repeat with :tc:`indexed-repeat(${question-name}, ${repeat-name}, index)`.
+
+.. _counting-repeats-and-answers:
+
+Counting repeats and answers
+------------------------------
+
+.. _counting-iterations:
+
+Counting the total number of repeat instances
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use `count(${name-of-repeat})` to get the number of repeat instances.
+
+.. _counting-answers:
+
+Counting the number of times a particular answer was given
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To count the number of times
+a specific response is given,
+add a calculate field inside the repeat
+which evaluates to ``1`` or ``0`` depending on the answer.
+Then, outside the repeat,
+calculate the :tc:`sum()` of the calculate field.
+
+.. include::  incl/form-examples/sum-to-count-responses.rst
+
+.. _using-parallel-repeat-groups:
+
+Using additional repeats to follow up on repeated questions
+-----------------------------------------------------------
+
+Sometimes it is convenient to gather an initial set of responses,
+and then ask more detailed question after you have collected the whole set.
+
+For example:
+
+ - collecting the names of all the people in a household, and then asking questions about each person
+ - collecting the names of each type of crop being grown, and then asking questions about each crop
+
+This can be done by using `count()` and `position(..)`. `count()` is used to guarantee that the second repeat has the same number of instances as the original repeat. `position(..)` provides the index of the repeat instance it was called from. This is used to refer to questions from the first repeat in the follow-up repeat.
+
+.. include:: incl/form-examples/parallel-repeats.rst
+
 .. _setting-max-repeats:
 
 Setting a max limit on repetitions
@@ -107,92 +177,3 @@ to enforce a minimum number of responses.
   image, image_3, Image 3, yes,
   image, image_4, Image 4, ,${image_3}
   image, image_5, Image 5, ,${image_4}
-
-.. _referencing-answers-in-repeats:
-  
-Referencing answers from repeated questions
---------------------------------------------
-
-Within a repeat group iteration,
-you can reference previous answers **in that same iteration**
-:ref:`in the usual manner <variables>`.
-
-.. rubric:: XLSForm
-
-.. csv-table:: survey
-  :header: type, name, label
-  
-  note, child_questions_note, Please provide the following details about each child in your household.
-  begin_repeat, child_details, Children in household
-  text, child_first_name, Name
-  text, child_age, Age of ${child_first_name}
-  end_repeat
-  
-To reference a response from a later iteration,
-or from outside the loop,
-use :func:`indexed-repeat` and :func:`position`.
-  
-
-
-.. _referencing-responses-from-outside-repeat-loop:
-  
-Referencing responses from outside the repeat loop
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The response to a question from
-any iteration of a repeat group can be referenced
-from outside the repeat group with
-:tc:`indexed-repeat(${question-name}, ${group-name}, index`.
-
-.. _using-parallel-repeat-groups:
-
-Using additional repeat groups to iterate through responses
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-Sometimes it is convenient to gather an initial set of responses,
-and then ask more detailed question after you have collected the whole set.
-
-For example:
-
- - collecting the names of all the people in a household, and then asking questions about each person
- - collecting the names of each type of crop being grown, and then asking questions about each crop
- 
-This can be done by using `count()` and `position(..)` 
-to iterate through a repeat group 
-in a second repeat group.
-
-.. include:: incl/form-examples/parallel-repeat-groups.rst
-
-.. _counting-repeats-and-answers:
-
-Counting repeats and answers
-------------------------------
-
-.. _counting-iterations:
-
-Counting the total number of iterations
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If there is a required response in the repeat group,
-use `count(${required-question-name})` to get the number of responses,
-which will be the same as the number of iterations.
-
-If you don't have at least one required field,
-use the `max()` function and refer to a calculate row
-with the calculation `position(..)`. 
-This will return the highest index,
-which is also the total number of iterations.
-
-.. _counting-answers:
-
-Counting the number of times a particular answer was given
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To count the number of times
-a specific response is given,
-add a calculate field inside the loop
-which evaluates to ``1`` or ``0`` depending on the answer.
-Then, outside the loop,
-calculate the :tc:`sum()` of the calculate field.
-
-.. include::  incl/form-examples/sum-to-count-responses.rst

--- a/odk1-src/form-repeats.rst
+++ b/odk1-src/form-repeats.rst
@@ -9,6 +9,12 @@
 Repeat Recipes and Tips
 ========================
 
+.. seealso::
+    :ref:`repeats` describes repeat basics.
+
+.. contents:: :depth: 2
+ :local:
+
 .. _setting-max-repeats:
 
 Setting a max limit on repetitions

--- a/odk1-src/incl/form-examples/parallel-repeats.rst
+++ b/odk1-src/incl/form-examples/parallel-repeats.rst
@@ -4,11 +4,11 @@
   :header: type, name, label, repeat_count, calculation
     
   note, person_list_note, Please list the names of the people in your household.,,
-  begin_repeat, name_group, Member of household, ,
+  begin_repeat, person, Member of household, ,
   text, name, Name, ,
   end_repeat,,,,
-  begin_repeat, member_details, Details, count(${name}) ,
-  calculate, current_name, , , "indexed-repeat(${name}, ${name-group}, position(..))"
+  begin_repeat, person_details, Details, count(${person}) ,
+  calculate, current_name, , , "indexed-repeat(${name}, ${person}, position(..))"
   date, member_bday, Birthday of ${current_name},,
   end_repeat,,,, 
   


### PR DESCRIPTION
closes #1042

#### What is included in this PR?

- an introduction to repeats
- a rework of the repeat count tip which wasn't right
- links between the repeat tips and repeat introduction sections
- an example for indefinite repeats (#1042)
- an example for 0 or more repeats

I'd like to keep adding recipes but I think this adds a lot of value already.

We're doing this now in the context of @seadowg taking a look at the repeat user experience in Collect.