### PR TITLE
xlsform example typo fix

### DIFF
--- a/odk1-src/form-operators-functions.rst
+++ b/odk1-src/form-operators-functions.rst
@@ -323,7 +323,7 @@ Select questions
 
       select_multiple colors, color_prefs, What colors do you like?, ¿Qué colores te gustan?, Select three., Seleccione tres.
       calculate, color_0, , , , ,"jr:choice-name( selected-at(${color_prefs}, 0), '${color_prefs}')"
-      calculate, color_1, , , , ,"jr:choice-name( selected-at(${color_prefs}, 2), '${color_prefs}')"
+      calculate, color_1, , , , ,"jr:choice-name( selected-at(${color_prefs}, 1), '${color_prefs}')"
       calculate, color_2, , , , ,"jr:choice-name( selected-at(${color_prefs}, 2), '${color_prefs}')"
       note, color_note, Selected colors:, Colores seleccionados:, ${color_0} <br> ${color_1} <br> ${color_2}, ${color_0} <br> ${color_1} <br> ${color_2}
 


### PR DESCRIPTION
`1` is missing and `2` is repeated
<img width="718" alt="Screen Shot 2019-11-14 at 12 28 59 PM" src="https://user-images.githubusercontent.com/4806884/68881235-c373ba00-06da-11ea-80ce-ff2851d0952b.png">
