### PR TITLE
Add identify user/track changes reasons docs

### DIFF
--- a/odk1-src/form-audit-log.rst
+++ b/odk1-src/form-audit-log.rst
@@ -93,6 +93,10 @@ You can enable change tracking so that old answers and new answers will be added
 Enumerator identification
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. versionadded:: 1.25
+
+  `ODK Collect v1.25.0 <https://github.com/opendatakit/collect/releases/tag/v1.25.0>`_
+
 If your form needs a record of the identity of the enumerator you can use :tc:`identify-user=true`.
 
 .. csv-table:: survey

--- a/odk1-src/form-audit-log.rst
+++ b/odk1-src/form-audit-log.rst
@@ -97,12 +97,12 @@ Tracking reason for edit
 
   `ODK Collect v1.25.0 <https://github.com/opendatakit/collect/releases/tag/v1.25.0>`_
 
-You can add to :tc:`track-changes-reason=on-form-edit` to prompt enumerators to enter a reason before they save changes to a form:
+You can add to :tc:`track-changes-reasons=on-form-edit` to prompt enumerators to enter a reason before they save changes to a form:
 
 .. csv-table:: survey
   :header: type, name, parameters
 
-  audit, audit, track-changes-reason=on-form-edit
+  audit, audit, track-changes-reasons=on-form-edit
 
 This will prevent filled out forms being edited without a reason being given. If a reason is given the form will be saved normally and the audit log will include a :tc:`change reason` event with the reason recorded in the :tc:`change-reason` column.
 

--- a/odk1-src/form-audit-log.rst
+++ b/odk1-src/form-audit-log.rst
@@ -97,14 +97,14 @@ Tracking reason for edit
 
   `ODK Collect v1.25.0 <https://github.com/opendatakit/collect/releases/tag/v1.25.0>`_
 
-You can add to :tc:`track-changes-reason=on-form-edit` to prompt enumerators to enter a reason when they save changes to a form:
+You can add to :tc:`track-changes-reason=on-form-edit` to prompt enumerators to enter a reason before they save changes to a form:
 
 .. csv-table:: survey
   :header: type, name, parameters
 
   audit, audit, track-changes-reason=on-form-edit
 
-This will prevent filled out forms being edited without a reason being given. If a reason is given the form will be saved as usual and the audit log will include a :tc:`change reason` event with the reason recorded in the :tc:`change-reason` column.
+This will prevent filled out forms being edited without a reason being given. If a reason is given the form will be saved normally and the audit log will include a :tc:`change reason` event with the reason recorded in the :tc:`change-reason` column.
 
 Enumerator identification
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/odk1-src/form-audit-log.rst
+++ b/odk1-src/form-audit-log.rst
@@ -90,6 +90,22 @@ You can enable change tracking so that old answers and new answers will be added
 
   audit, audit, track-changes=true
 
+Tracking reason for edit
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.25
+
+  `ODK Collect v1.25.0 <https://github.com/opendatakit/collect/releases/tag/v1.25.0>`_
+
+You can add to :tc:`track-changes-reason=on-form-edit` to prompt enumerators to enter a reason when they save changes to a form:
+
+.. csv-table:: survey
+  :header: type, name, parameters
+
+  audit, audit, track-changes-reason=on-form-edit
+
+This will prevent filled out forms being edited without a reason being given. If a reason is given the form will be saved as usual and the audit log will include a :tc:`change reason` event with the reason recorded in the :tc:`change-reason` column.
+
 Enumerator identification
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -107,7 +123,7 @@ If your form needs a record of the identity of the enumerator you can use :tc:`i
 This will cause Collect to prompt the enumerator for their identity before filling out or editing a form instance. In the audit log, a :tc:`user` column will be included that will be populated for each event. The enumerator will not be able to fill in or edit the form without entering a non-blank identity.
 
 .. tip::
-  :tc:`identify-user` feature is useful for data collection workflows where devices might be passed between multiple enumerators for data verification or completion.
+  :tc:`identify-user` is useful for data collection workflows where devices might be passed between multiple enumerators for data verification or completion.
 
   In cases where a device will only ever used by a single enumerator, it might make more sense to use :ref:`username metadata <metadata>`. This will write the username to each submission instead of to the audit log.
 

--- a/odk1-src/form-audit-log.rst
+++ b/odk1-src/form-audit-log.rst
@@ -90,6 +90,17 @@ You can enable change tracking so that old answers and new answers will be added
 
   audit, audit, track-changes=true
 
+Enumerator identification
+~~~~~~~~~~~~~~~
+
+If your form needs a record of the identity of the enumerator you can use :tc:`identify-user=true`.
+
+.. csv-table:: survey
+  :header: type, name, parameters
+
+  audit, audit, identify-user=true
+
+This will cause Collect to prompt the enumerator for their identity before filling out or editing a form instance. In the audit log, a :tc:`user` column will be included that will be populated for each event. The enumerator will not be able to fill in or edit the form without entering a non-blank identity.
 
 Viewing audit logs
 -------------------

--- a/odk1-src/form-audit-log.rst
+++ b/odk1-src/form-audit-log.rst
@@ -102,6 +102,11 @@ If your form needs a record of the identity of the enumerator you can use :tc:`i
 
 This will cause Collect to prompt the enumerator for their identity before filling out or editing a form instance. In the audit log, a :tc:`user` column will be included that will be populated for each event. The enumerator will not be able to fill in or edit the form without entering a non-blank identity.
 
+.. tip::
+  :tc:`identify-user` feature is useful for data collection workflows where devices might be passed between multiple enumerators for data verification or completion.
+
+  In cases where a device will only ever used by a single enumerator, it might make more sense to use :ref:`username metadata <metadata>`. This will write the username to each submission instead of to the audit log.
+
 Viewing audit logs
 -------------------
 

--- a/odk1-src/form-audit-log.rst
+++ b/odk1-src/form-audit-log.rst
@@ -91,7 +91,7 @@ You can enable change tracking so that old answers and new answers will be added
   audit, audit, track-changes=true
 
 Enumerator identification
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If your form needs a record of the identity of the enumerator you can use :tc:`identify-user=true`.
 


### PR DESCRIPTION
Closes #1155.

#### What is included in this PR?

A new section in the form audit docs around `identify-user`. Was originally thinking of including screenshots but not sure we need it for this. Interested in if others disagree!
