### PR TITLE
Adding a note for Windows 10 users and a line edit.

### DIFF
--- a/odkx-src/select-tool-suite.rst
+++ b/odkx-src/select-tool-suite.rst
@@ -73,6 +73,6 @@ The feature comparison table below illustrates the differences between the ODK a
 
 Trying Them Out
 -----------------------------
-  - Try the 1.x tools with the :doc:`getting-started` guide.
-  - Try the 2.x tools with the :doc:`getting-started-2-user`.
+  - Try the ODK tools with the :doc:`getting-started` guide.
+  - Try the ODK-X tools with the :doc:`getting-started-2-user`.
 

--- a/shared-src/docs-tech-guide.rst
+++ b/shared-src/docs-tech-guide.rst
@@ -187,6 +187,7 @@ Before you begin working the first time
 you will need to install a few tools
 on your computer.
 
+
 You should only need to do this one time
 on any computer.
 
@@ -228,7 +229,13 @@ on any computer.
          If you decide to use the Linux subsystem,
          follow the **Bash** or **Windows** instructions
          throughout the contributor guide.
+		
+	  .. note::
 
+		 Computers with the Windows 10 Home operating system are incapable of 
+		 installing some of the tools necessary to edit the docs. Other Windows
+		 operating systems, such as Windows 10 Enterprise or Pro, can be used
+		 to edit the docs. 
 
       .. group-tab:: Mac
 

--- a/shared-src/docs-tech-guide.rst
+++ b/shared-src/docs-tech-guide.rst
@@ -871,7 +871,7 @@ on any computer.
    - `Atom <https://atom.io/>`_
    - `Sublime <https://www.sublimetext.com/>`_
    - `VS Code <https://code.visualstudio.com/>`_
-   - `Notebook++ <https://notepad-plus-plus.org/>`_ (Windows only)
+   - `Notepad++ <https://notepad-plus-plus.org/>`_ (Windows only)
 
    Most of these have plugins that will make writing reStructuredText easier
    by color-coding the markup.
@@ -1071,9 +1071,9 @@ Working on the docs
    The source files for documentation text are in these directories:
 
    :file:`odk1-src`
-      Files for the pages at https://docs.opendatakit.com
+      Files for the pages at https://docs.opendatakit.org
    :file:`odkx-src`
-      Files for the pages at https://docs.opendatakit.com/odk-x
+      Files for the pages at https://docs.opendatakit.org/odk-x
    :file:`shared-src`
       Files for pages shared by both ODK1 and ODK-X docs.
       (This page and the other contributor guide pages.)


### PR DESCRIPTION
<!-- ALL PRs MUST BE RELATED TO AN OPEN ISSUE -->
addresses #823 & #96

#### What is included in this PR?
I added a note to the Docs Contributor Technical Guide that the Python tools necessary to install 
to edit the docs are incompatible with Windows 10 Home. Also, I edited the ODK-X Selecting the Appropriate Tool Suite "Trying Them Out" section to remove jargon. 

<!-- Answer any that apply and delete the others. -->
#### What new issues will need to be opened because of this PR?
If possible, modifying Sphinx to replace the pyenchant 2.0.0 Python tool with a similar tool that does not cause issues for Windows 10 Home users. 
