### PR TITLE
I edited the ODK-X docs to remove "Deployment Architect" language.

### DIFF
--- a/odkx-src/advanced-topics-architect.rst
+++ b/odkx-src/advanced-topics-architect.rst
@@ -1,10 +1,7 @@
-Deployment Architect Advanced Topics
+Advanced Application Building Topics
 =======================================
 
 .. _advanced-architect:
-
-This section covers advanced topics useful to Deployment Architects. A Deployment Architect is an author of a data management application or a consumer of collected data. This person might create forms and edit Javascript on their computer to deploy to the Android device. Or they might download data from the server and use Excel to perform analysis. Examples include technical staff and data analytics staff.
-
 
 .. toctree::
   :maxdepth: 2

--- a/odkx-src/app-designer-intro.rst
+++ b/odkx-src/app-designer-intro.rst
@@ -25,15 +25,13 @@ The major goals of the ODK Application Designer are:
   #. Simplify the conversion of the XLSX file into a form definition by providing a drag-and-drop conversion app running locally on your desktop.
   #. Enable the creation of mark-sense forms (ODK Scan Form Designer) that can be scanned by your Android device for data input. The resulting data is available to the other ODK-X tools without need to communicate with a remote server.
 
-.. _app-designer-intro-architect-guide:
+.. _app-designer-intro-learn-more:
 
-Deployment Architect Guide
+Learn more about ODK Application Designer
 -----------------------------------------------------
-.. toctree::
-  :maxdepth: 2
 
-  app-designer-setup
-  app-designer-using
-  xlsx-converter-intro
-  scan-form-designer-intro
+- :doc:`app-designer-setup`
+- :doc:`app-designer-using`
+- :doc:`xlsx-converter-intro`
+- :doc:`scan-form-designer-intro`
 

--- a/odkx-src/build-app.rst
+++ b/odkx-src/build-app.rst
@@ -16,11 +16,6 @@ Building an Application
 
 This will walk you through the steps of building a Data Management Application from scratch. The goal is to start with an empty folder and show you the necessary steps to create a working application that runs on your Android device.
 
-.. note::
-
-  This section covers topics useful to Deployment Architects. A Deployment Architect is an author of a data management application or a consumer of collected data. This person might create forms and edit Javascript on their computer to deploy to the Android device. Or they might download data from the server and use Excel to perform analysis. Examples include technical staff and data analytics staff.
-
-
 .. _build-app-prereqs:
 
 Prerequisites

--- a/odkx-src/cloud-endpoints-intro.rst
+++ b/odkx-src/cloud-endpoints-intro.rst
@@ -10,14 +10,11 @@ There are currently two options for Cloud Endpoints to communicate with ODK-X to
   - :doc:`sync-endpoint` - Supports the full ODK-X REST Protocol
   - :doc:`aggregate-tables-extension` - Supports the majority of the ODK-X REST Protocol; however, is missing group permission filtering support.
 
-.. _cloud-endpoints_intro_sys-admin-guide:
+.. _cloud-endpoints_intro_learn-more:
 
-System Administrator Guide
----------------------------
+Learn more about ODK Cloud Endpoints
+-------------------------------------------
 
-.. toctree::
-
-  sync-endpoint
-  sync-endpoint-setup
-  aggregate-tables-extension
-
+- :doc:`sync-endpoint`
+- :doc:`sync-endpoint-setup`
+- :doc:`aggregate-tables-extension`

--- a/odkx-src/cold-chain-tour-initial-data.rst
+++ b/odkx-src/cold-chain-tour-initial-data.rst
@@ -9,7 +9,7 @@ Initial Data Set
 Function
 -----------------
 
-The initial data set is not part of the actual workflow of the application, but is described here to provide context for how this application is set up and how it might be used in the field. This initial data set is the full list of health facilities, refrigerators, and refrigerator types that currently exist in the health system to be modeled. The initial Deployment Architect could choose to collect this data via survey forms within the application itself (which are already provided, and used for adding data as the current state changes), but if they already have a database of health facility inventory, this might be the more convenient method.
+The initial data set is not part of the actual workflow of the application, but is described here to provide context for how this application is set up and how it might be used in the field. This initial data set is the full list of health facilities, refrigerators, and refrigerator types that currently exist in the health system to be modeled. The initial person configuring the application could choose to collect this data via survey forms within the application itself (which are already provided, and used for adding data as the current state changes), but if they already have a database of health facility inventory, this might be the more convenient method.
 
 For demonstration purposes the provided default data set also has maintenance logs that are seeded into the database.
 

--- a/odkx-src/episample-tour-household-survey.rst
+++ b/odkx-src/episample-tour-household-survey.rst
@@ -14,7 +14,7 @@ Household Data Collection
 Function
 --------------
 
-The Household Data Collection module is an ODK Survey form that is configured in the :doc:`episample-tour-config` module. This is intended to be provided by the Deployment Architect for their particular use case, which makes this application flexible to different scenarios. For example, this could be used for follow up after a Malaria outbreak or it could be adapted to handle another disease by swapping this form.
+The Household Data Collection module is an ODK Survey form that is configured in the :doc:`episample-tour-config` module. An organization is intended to provide this for its particular use case, which makes this application flexible to different scenarios. For example, this could be used for follow-up after a Malaria outbreak or it could be adapted to handle another disease by swapping this form.
 
 The data collected in this form is available in the same database as the rest of the application and can be used by it.
 

--- a/odkx-src/getting-started-2-architect.rst
+++ b/odkx-src/getting-started-2-architect.rst
@@ -1,9 +1,7 @@
-Getting Started Deployment Architect Guide
+Getting Started Building an Application
 ==========================================================
 
-.. _architect-odk-2:
-
-This guide is intended for Deployment Architects. A Deployment Architect is an author of a data management application or a consumer of collected data. This person might create forms and edit Javascript on their computer to deploy to the Android device. Or they might download data from the server and use Excel to perform analysis. Examples include technical staff and data analytics staff.
+Now that we have seen how a device can join an already-configured application, and synchronize its view of the data with the ODK Aggregate server hosting the application, it is time to set up our own ODK-X application.
 
 .. contents:: :local:
 
@@ -11,14 +9,9 @@ This guide is intended for Deployment Architects. A Deployment Architect is an a
 
 Prerequisites
 ------------------
-This guide continues the tour were :doc:`getting-started-2-user` left off. If you haven't yet completed that tour, do it first. When you have concluded the tour of the *Geotagger* example application's screens, return to this guide and we will turn to setting up our own application and server.
+This guide continues the tour where :doc:`getting-started-2-user` left off. If you haven't yet completed that tour, do it first. When you have concluded the tour of the *Geotagger* example application's screens, return to this guide and we will turn to setting up our own application and server.
 
 .. _architect-odk-2-setting-up:
-
-Setting-up an ODK-X application
-------------------------------------------------
-
-Now that we have seen how a device can join an already-configured application, and synchronize its view of the data with the ODK Aggregate server hosting the application, it is time to set up our own ODK-X application.
 
 Configuring your Device with an Application
 -----------------------------------------------
@@ -323,7 +316,7 @@ A more complete guide to using ODK XLSX Converter is provided in the :doc:`xlsx-
 
 For examples of real world applications and details about they are implemented, try out the: :doc:`reference-apps`.
 
-We also provide guides geared towards Deployment Architects for each of the Android and Desktop tools.
+We also provide guides for setting up your own ODK-X application for each of the Android and Desktop tools.
 
   - :doc:`survey-managing`
   - :doc:`tables-managing`

--- a/odkx-src/getting-started-2-user.rst
+++ b/odkx-src/getting-started-2-user.rst
@@ -9,7 +9,7 @@ The ODK-X tools are intended to address limitations of the existing tool set. Th
 
 - :doc:`survey-intro` - a data collection application based upon HTML, CSS, and JavaScript.
 - :doc:`tables-intro` - a data collection and visualization application running on your device.
-- :doc:`services-intro` - an application that handles database access, file access, and data synchronization services between all of the ODK 2 applications. It also allows you to synchronize data collected by the ODK 2 tools using the 2 protocol with an ODK Aggregate instance.
+- :doc:`services-intro` - an application that handles database access, file access, and data synchronization services between all of the ODK-X applications. It also allows you to synchronize data collected by the ODK-X tools using the 2 protocol with an ODK Aggregate instance.
 - :doc:`app-designer-intro` - a design environment for creating, customizing, and previewing your forms.
 - :doc:`cloud-endpoints-intro` - a ready-to-deploy server and data repository with enhancements to support bi-directional data synchronization across disconnected devices.
 - :doc:`suitcase-intro` - a desktop tool for synchronizing data from an ODK-X server so the data can be exported to CSV format.
@@ -202,4 +202,4 @@ Users can browse the user guides for the Android tools. Tables and Survey's docu
   - :doc:`services-intro`
 
 
-Development Architects should continue this tour in the :doc:`getting-started-2-architect`.
+Those interested in building applications should continue this tour in the :doc:`getting-started-2-architect`.

--- a/odkx-src/index.rst
+++ b/odkx-src/index.rst
@@ -105,21 +105,75 @@ The :doc:`getting-started-2-user` walks you through the process of using a basic
 .. toctree::
   :maxdepth: 2
   :hidden:
-  :caption: Mobile Tools
+  :caption: Survey
 
   survey-intro
-  tables-intro
-  services-intro
-  scan-intro
+  survey-install
+  survey-sample-app
+  survey-using
+  survey-managing
 
 .. toctree::
   :maxdepth: 2
   :hidden:
-  :caption: Desktop and Server Tools
+  :caption: Tables
+  
+  tables-intro
+  tables-install
+  tables-sample-app
+  tables-using
+  tables-managing
+  tables-internals
+
+.. toctree::
+  :maxdepth: 2
+  :hidden:
+  :caption: Services
+  
+  services-intro
+  services-install
+  services-using
+  services-managing
+  services-internals
+
+.. toctree::
+  :maxdepth: 2
+  :hidden:
+  :caption: Scan
+  
+  scan-intro
+  scan-install
+  scan-using
+  scan-managing
+  scan-data
+  
+.. toctree::
+  :maxdepth: 2
+  :hidden:
+  :caption: Application Designer
 
   app-designer-intro
+  app-designer-setup
+  app-designer-using
+
+.. toctree::
+  :maxdepth: 2
+  :hidden:
+  :caption: Cloud Endpoints
+
   cloud-endpoints-intro
+  sync-endpoint
+  sync-endpoint-setup
+  aggregate-tables-extension
+
+.. toctree::
+  :maxdepth: 2
+  :hidden:
+  :caption: Suitcase
+
   suitcase-intro
+  suitcase-install
+  suitcase-using
 
 .. toctree::
   :maxdepth: 2

--- a/odkx-src/scan-form-designer-intro.rst
+++ b/odkx-src/scan-form-designer-intro.rst
@@ -24,10 +24,6 @@ Video tutorials for each of these steps --from designing to exporting your form 
 
 Once you have exported your completed form you can transfer the form template to the ODK Scan app and begin scanning paper forms. See the :doc:`scan-intro` documentation for more on those next steps.
 
-.. _scan-form-architect-guide:
-
-Deployment Architect Guide
----------------------------------------------
 
 .. toctree::
   :maxdepth: 2

--- a/odkx-src/scan-intro.rst
+++ b/odkx-src/scan-intro.rst
@@ -14,24 +14,14 @@ ODK Scan
 .. image:: /img/scan-intro/scan-process.*
   :alt: The ODK Scan Process
 
-.. _scan-intro-user-guide:
+.. _scan-intro-learn-more:
 
-User Guide
+Learn more about ODK Scan
 ----------------------------
 
-.. toctree::
-  :maxdepth: 2
-
-  scan-install
-  scan-using
-
-.. _scan-intro-architect-guide:
-
-Deployment Architect Guide
-----------------------------
-
-.. toctree::
-  :maxdepth: 2
-
-  scan-managing
-  scan-data
+- :doc:`scan-install`
+- :doc:`scan-using`
+- :doc:`scan-managing`
+- :doc:`scan-data`
+  
+  

--- a/odkx-src/select-tool-suite.rst
+++ b/odkx-src/select-tool-suite.rst
@@ -73,6 +73,6 @@ The feature comparison table below illustrates the differences between the ODK a
 
 Trying Them Out
 -----------------------------
-  - Try the 1.x tools with the :doc:`getting-started` guide.
-  - Try the 2.x tools with the :doc:`getting-started-2-user`.
+  - Try the ODK tools with the :doc:`getting-started` guide.
+  - Try the ODK-X tools with the :doc:`getting-started-2-user`.
 

--- a/odkx-src/services-intro.rst
+++ b/odkx-src/services-intro.rst
@@ -7,24 +7,15 @@ ODK Services
 
 It also allows you to sync data collected by the ODK-X tools with an ODK Cloud Endpoint. The Services application can be used to reset the Cloud Endpoint with the data that is on a tablet or to sync the data on the tablet with what is currently on the Cloud Endpoint.
 
-.. _services-intro-user-guide:
+.. _services-intro-learn-more:
 
-User Guide
+Learn more about ODK Services
 -----------------------------
 
-.. toctree::
-  :maxdepth: 2
+- :doc:`services-install`
+- :doc:`services-using`
+- :doc:`services-managing`
+- :doc:`services-internals`
 
-  services-install
-  services-using
-
-.. _services-intro-architect-guide:
-
-Deployment Architect Guide
-----------------------------------
-
-.. toctree::
-  :maxdepth: 2
-
-  services-managing
-  services-internals
+  
+  

--- a/odkx-src/services-using.rst
+++ b/odkx-src/services-using.rst
@@ -7,7 +7,7 @@ Using ODK Services
 
 Initial Server Configuration
 -----------------------------------
-Before you are able to synchronize your data or application files, you will need to configure your server settings. Instructions are provided in the :ref:`deployment architect guide <services-managing-server-config>`.
+Before you are able to synchronize your data or application files, you will need to configure your server settings. Instructions are provided in the :ref:`Server Configuration guide <services-managing-server-config>`.
 
 .. _services-using-change-user:
 
@@ -39,7 +39,7 @@ Within this page you can enter a new :guilabel:`username` and :guilabel:`passwor
 
 .. note::
 
-  To authenticate a new user, you must have a network connection and have the Server URL set appropriately. See the :ref:`deployment architect guide <services-managing-server-config>` for instructions on how to set this.
+  To authenticate a new user, you must have a network connection and have the Server URL set appropriately. See the :ref:`Server Configuration guide <services-managing-server-config>` for instructions on how to set this.
 
 If you want to log out of your current user without logging into a new user, click the :guilabel:`Log Out` button. This does not require a network connection.
 
@@ -48,7 +48,7 @@ If you want to log out of your current user without logging into a new user, cli
 Syncing
 ---------------
 
-Use this option to submit your data and download the latest updates from the server. When this process is finished, the data on your device and the server will match. You will also receive any updates to your application that your Deployment Architect might have made.
+Use this option to submit your data and download the latest updates from the server. When this process is finished, the data on your device and the server will match. You will also receive any updates to your application that those at your organization managing the application might have made.
 
 There are two ways to launch the Sync screen.
 

--- a/odkx-src/suitcase-intro.rst
+++ b/odkx-src/suitcase-intro.rst
@@ -7,12 +7,10 @@ ODK Suitcase
 
 Data downloaded from an :doc:`cloud-endpoints-intro` is stored as spreadsheets in CSV format. This format is compatible with most spreadsheet software, for example :program:`Excel` or :program:`Numbers`. Once downloaded, the spreadsheets will be available for offline viewing. Similarly, data to be uploaded to an ODK Cloud Endpoint must be stored in a properly formatted csv file.
 
-.. _suitcase-intro-architect-guide:
+.. _suitcase-intro-learn-more:
 
-Deployment Architect Guide
+Learn more about ODK Suitcase
 -------------------------------------
 
-.. toctree::
-
-  suitcase-install
-  suitcase-using
+- :doc:`suitcase-install`
+- :doc:`suitcase-using`

--- a/odkx-src/survey-intro.rst
+++ b/odkx-src/survey-intro.rst
@@ -13,24 +13,13 @@ ODK Survey
 
   ODK Survey cannot read or display the forms created for ODK Collect (that is, those created via ODK Build, XLSForm, or other form design tools). ODK Survey operates with ODK-X Data Management Applications*.
 
-.. _survey-intro-user-guide:
+.. _survey-intro-learn-more:
 
-User Guide
+Learn more about ODK Survey
 ---------------------------------
 
-.. toctree::
-  :maxdepth: 2
+- :doc:`survey-install`
+- :doc:`survey-sample-app`
+- :doc:`survey-using`
+- :doc:`survey-managing`
 
-  survey-install
-  survey-sample-app
-  survey-using
-
-.. _survey-intro-architect-guide:
-
-Deployment Architect Guide
----------------------------------
-
-.. toctree::
-  :maxdepth: 2
-
-  survey-managing

--- a/odkx-src/survey-sample-app-end.rst
+++ b/odkx-src/survey-sample-app-end.rst
@@ -5,4 +5,4 @@ Explore the Sample Application
 
 This concludes the guided tour of the sample application for Survey. However, this is far from a complete reference. Please continue to explore the different forms and prompts to learn more about the tool's capabilities.
 
-You can find a more detailed user guide for Survey here: :doc:`survey-using`. And you can find a more detailed guide to managing Survey for Deployment Architects here: :doc:`survey-managing`. You can also find the sample forms shown in this tutorial in the Github repository for `App Designer <https://github.com/opendatakit/app-designer/>`_.
+You can find a more detailed user guide for Survey here: :doc:`survey-using`. Additionally, you can find a more detailed guide to managing ODK Survey here: :doc:`survey-managing`. You can also find the sample forms shown in this tutorial in the Github repository for `App Designer <https://github.com/opendatakit/app-designer/>`_.

--- a/odkx-src/survey-sample-app.rst
+++ b/odkx-src/survey-sample-app.rst
@@ -1,4 +1,4 @@
-ODK Survey: Sample Application
+Sample ODK Survey Application
 ====================================
 
 .. _survey-sample-app:

--- a/odkx-src/tables-intro.rst
+++ b/odkx-src/tables-intro.rst
@@ -16,23 +16,10 @@ We have included a sample application built on top of Tables along with a handfu
 
 .. _tables-intro-user-guide:
 
-User Guide
--------------------------------
-
-.. toctree::
-  :maxdepth: 2
-
-  tables-install
-  tables-sample-app
-  tables-using
-
-.. _tables-intro-architect-guide:
-
-Deployment Architect Guide
--------------------------------
-
-.. toctree::
-  :maxdepth: 2
-
-  tables-managing
-  tables-internals
+Learn more about ODK Aggregate
+--------------------------------
+- :doc:`tables-install`
+- :doc:`tables-sample-app`
+- :doc:`tables-using`
+- :doc:`tables-managing`
+- :doc:`tables-internals`

--- a/odkx-src/tables-managing.rst
+++ b/odkx-src/tables-managing.rst
@@ -210,7 +210,7 @@ Tapping the :guilabel:`Columns` item will launch a list of all the columns in th
 
   .. note::
 
-      The columns list excludes the status and metadata columns that the ODK-X platform automatically adds. It only shows the columns holding data defined by the Deployment Architect.
+      The columns list excludes the status and metadata columns that the ODK-X platform automatically adds. It only shows the columns holding data as defined by your organization.
 
   .. image:: /img/tables-managing/table-properties-column-list.*
     :alt: Table Properties Column List

--- a/odkx-src/tables-sample-app-end.rst
+++ b/odkx-src/tables-sample-app-end.rst
@@ -5,5 +5,5 @@ Explore the Sample Application
 
 This concludes the guided tour of the sample application for Tables. However, this is far from a complete reference. Please continue to explore the demo applications to learn more about the tool's capabilities.
 
-You can find a more detailed user guide for Tables here: :doc:`tables-using`. And you can find a more detailed guide to managing Tables for Deployment Architects here: :doc:`tables-managing`. You can also find the source code for the demo applications in this tutorial in the Github repository for `App Designer <https://github.com/opendatakit/app-designer/>`_.
+You can find a more detailed user guide for Tables here: :doc:`tables-using`. Additionally, you can find a more detailed guide to managing ODK Tables here: :doc:`tables-managing`. You can also find the source code for the demo applications in this tutorial in the Github repository for `App Designer <https://github.com/opendatakit/app-designer/>`_.
 

--- a/odkx-src/tables-sample-app.rst
+++ b/odkx-src/tables-sample-app.rst
@@ -1,4 +1,4 @@
-ODK Tables: Sample Application
+Sample ODK Tables Application
 ===============================================
 
 In this guide we will be demonstrating how to use ODK Tables via a guided tour of a sample application.

--- a/odkx-src/tables-using.rst
+++ b/odkx-src/tables-using.rst
@@ -50,7 +50,7 @@ To enable or disable the use of the custom home screen, follow the instructions 
 Table Manager
 ------------------
 
-The *Table Manager* allows you to modify table settings, delete tables, and import or export data into your tables. See the :ref:`Deployment Architect instructions <tables-managing-table-manager>` for details.
+The *Table Manager* allows you to modify table settings, delete tables, and import or export data into your tables. See the :ref:`Table Manager instructions <tables-managing-table-manager>` for details.
 
 .. _tables-using-view-data:
 
@@ -64,7 +64,7 @@ Tables supports viewing collected data in a variety of formats. Survey allows yo
 View Types
 ~~~~~~~~~~~~~~~~~
 
-Tables offers a number of view options for presenting data. These will have been configured by your organizations Deployment Architect and you may not always have a choice in how you view your data. These view types are:
+Tables offers a number of view options for presenting data. The person at your organization who built this ODK Tables application will have already configured these options, so you may not always have a choice in how you view your data. These view types are:
 
   - :ref:`Spreadsheet View <tables-using-view-data-spreadsheet>`
   - :ref:`List View <tables-using-view-data-list>`
@@ -77,7 +77,7 @@ Tables offers a number of view options for presenting data. These will have been
 
 .. warning::
 
-  Many of the view types in Tables are customizable by a Deployment Architect. This guide will provide some basic outlines of how to use these view types, but for more accurate instructions you may need to contact your organization's Deployment Architect.
+  Many of the view types in Tables are customizable. This guide will provide some basic outlines of how to use these view types. However, for more accurate instructions you may need to contact the person who built or manages your organization’s ODK Tables application. 
 
 
 .. _tables-using-view-data-spreadsheet:
@@ -239,7 +239,7 @@ Custom View
 Changing View Types: The Lined Paper Button
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The view types that represent multiple records (:ref:`tables-using-view-data-spreadsheet`, :ref:`tables-using-view-data-list`, :ref:`tables-using-view-data-map`, :ref:`tables-using-view-data-navigate`) can be alternately chosen, depending on what the Deployment Architect has configured in the table's settings.
+The view types that represent multiple records (:ref:`tables-using-view-data-spreadsheet`, :ref:`tables-using-view-data-list`, :ref:`tables-using-view-data-map`, :ref:`tables-using-view-data-navigate`) can be alternately chosen, depending on what was configured in the table's settings.
 
 To change to another view type, tap the lined paper icon from the upper right:
 

--- a/odkx-src/xlsx-converter-intro.rst
+++ b/odkx-src/xlsx-converter-intro.rst
@@ -29,10 +29,6 @@ Will result in a survey like this:
 
   See :file:`exampleForm.xlsx` (located at the path :file:`app/config/tables/exampleForm/forms/exampleForm/` in the Application Designer) for a more extensive list of examples.
 
-.. _xlsx-converter-intro-architect-guide:
-
-Deployment Architect Guide
-------------------------------------
 
 .. toctree::
   :maxdepth: 2


### PR DESCRIPTION
<!-- ALL PRs MUST BE RELATED TO AN OPEN ISSUE -->
addresses #1139

#### What is included in this PR?
As a beginning step in revising the ODK-X Docs learning paths, I went through and removed the "Deployment Architect" jargon, and reorganized the sections to be more consistent with the ODK Docs flow. 

<!-- Answer any that apply and delete the others. -->

#### What is left to be done in the addressed issue?
The learning paths need to be further revised to simplify and to remove redundancies. 
