### PR TITLE
Dynamic defaults and ${last-saved#question_name}

### DIFF
--- a/odk1-src/form-logic.rst
+++ b/odk1-src/form-logic.rst
@@ -240,44 +240,69 @@ without answering the question.
 Setting default responses
 ===========================
 
-To provide a default response to a question,
-put the response value in the :th:`default` column.
+To provide a default response to a question, put a value in the :th:`default` column. Defaults are set once when each instance of a form definition is first opened for filling and can then be changed by enumerators. Defaults can either be fixed values (:ref:`static defaults <static-defaults>`) or the result of some expression (:ref:`dynamic defaults <dynamic-defaults>`).
 
-Default values must be static values,
-not expressions or variables.
+.. _static-defaults:
 
-.. note::
+Static defaults
+----------------
 
-  The content of the :th:`default` row in a question
-  is taken literally as the default value.
-  Quotes should **not** be used to wrap string values,
-  unless you actually want those quote marks to appear
-  in the default response value.
+The text in the :th:`default` column for a question is taken literally as the default value. Quotes should **not** be used to wrap values, unless you actually want those quote marks to appear in the default response value.
 
-.. rubric:: XLSForm
+In the example below, the "Phone call" option with underlying value ``phone_call`` will be selected when the question is first displayed. The enumerator can either keep that selection or change it.
+
+.. rubric:: XLSForm to select "Phone call" as the default contact method
 
 .. csv-table:: survey
   :header: type, name, label, default
-  
+
   select_one contacts, contact_method, How should we contact you?, phone_call
-  
+
 .. csv-table:: choices
   :header: list_name, name, label
-  
+
   contacts, phone_call, Phone call
   contacts, text_message, Text message
   contacts, email, Email
-  
-.. tip:: 
-  :name: dynamic-defaults
 
-  You may want to use a previously entered value as a default,
-  but the :th:`default` column does not accept dynamic values.
+.. _dynamic-defaults:
+
+Dynamic defaults
+----------------
+
+.. warning::
   
-  To work around this, use the :th:`calculation` column instead,
-  and wrap your default value expression in a :func:`once` function.
+  Support for :ref:`dynamic defaults <dynamic-defaults>` was added in Collect v1.24.0. Form conversion requires XLSForm Online ≥ v2.0.0 or pyxform ≥ v1.0.0.
+
+If you put an expression in the :th:`default` column for a question, that expression will be evaluated once when an instance of a form definition is first opened. This allows you to use values from outside the form like the current date or the :ref:`server username <metadata>`.
+
+.. rubric:: XLSForm to set the current date as default
+
+.. csv-table:: survey
+  :header: type, name, label, default
+
+  date, fever_onset, When did the fever start?, now()
+
+In the example below, if a username is set either in the :ref:`server configuration <server-settings>` or the :ref:`metadata settings <form-metadata-settings>`, that username will be used as the default for the question asked to the enumerator.
+
+.. rubric:: XLSForm to set the default username as the server username
+
+.. csv-table:: survey
+  :header: type, name, label, default
+
+  username, username
+  text, confirmed_username, What is your username?, ${username}
+
+Dynamic defaults in repeats are evaluated when a new repeat instance is added.
+
+.. tip:: 
+  :name: defaults-from-form-data
+
+  You may want to use a value filled out by the enumerator as a default for another question that the enumerator will later fill in. Dynamic defaults can't be used for this because they are evaluated once when a form definition is first loaded and before an enumerator fills in any data.
   
-  .. rubric:: XLSForm
+  One option is to use the :th:`calculation` column and wrap your default value expression in a :func:`once` function.
+  
+  .. rubric:: XLSForm that uses a child's current age as the default for diagnosis age
   
   .. csv-table:: survey
     :header: type, name, label, calculation
@@ -287,7 +312,7 @@ not expressions or variables.
     select_one gndr, gender, Gender,
     integer, malaria_age, Age at malaria diagnosis, once(${current_age}) 
     
-  This solution has some limitations, though.
+  This solution has some limitations:
   
   - The value of the calculated default
     will get set to the first value that the earlier question receives,

--- a/odk1-src/form-logic.rst
+++ b/odk1-src/form-logic.rst
@@ -264,7 +264,7 @@ without answering the question.
 Setting default responses
 ===========================
 
-To provide a default response to a question, put a value in the :th:`default` column. Defaults are set once when a record is first created from a form definition. Defaults can either be fixed values (:ref:`static defaults <static-defaults>`) or the result of some expression (:ref:`dynamic defaults <dynamic-defaults>`). 
+To provide a default response to a question, put a value in the :th:`default` column. Defaults are set when a record is first created from a form definition. Defaults can either be fixed values (:ref:`static defaults <static-defaults>`) or the result of some expression (:ref:`dynamic defaults <dynamic-defaults>`).
 
 .. _static-defaults:
 
@@ -298,7 +298,7 @@ Dynamic defaults
   
   Support for :ref:`dynamic defaults <dynamic-defaults>` was added in Collect v1.24.0. Form conversion requires XLSForm Online ≥ v2.0.0 or pyxform ≥ v1.0.0. Using older versions will have unpredictable results.
 
-If you put an expression in the :th:`default` column for a question, that expression will be evaluated once when a record is first created from a blank form definition. This allows you to use values from outside the form like the current date or the :ref:`server username <metadata>`. Dynamic defaults can't be used to base the default value of one field on the value of another field in the form. For example, if you have an ``age`` question and you want to default the diagnosis age to the value of the ``age`` question, see :ref:`the tip below <defaults-from-form-data>`.
+If you put an expression in the :th:`default` column for a question, that expression will be evaluated once when a record is first created from a form definition. This allows you to use values from outside the form like the current date or the :ref:`server username <metadata>`. Dynamic defaults can't be used to set the default value of one field to the value of another field in the form. Learn about alternatives in :ref:`the tip below <defaults-from-form-data>`.
 
 .. rubric:: XLSForm to set the current date as default
 

--- a/odk1-src/form-logic.rst
+++ b/odk1-src/form-logic.rst
@@ -147,13 +147,13 @@ Values from the last saved record
 
 .. warning::
 
-  Support for last-saved was added in Collect v1.21.0. Form conversion requires XLSForm Online ≥ v2.0.0 or pyxform ≥ v1.0.0.
+  Support for last-saved was added in Collect v1.21.0. Form conversion requires XLSForm Online ≥ v2.0.0 or pyxform ≥ v1.0.0. Using older versions will have unpredictable results.
 
-You can refer to values from the last saved record by wrapping a question name in ``${last-saved#`` and ``}``:
+You can refer to values from the last saved record of this form definition:
 
 :tc:`${last-saved#question-name}`
 
-This can be very useful when an enumerator is expected to fill out the same  form definition for groups of things with the same property. For example, if an enumerator is walking through a town and collecting information about people including the street that they live on, the street name will be the same for several records in a row.
+This can be very useful when an enumerator has to enter the same value for multiple consecutive records. An example of this would be entering in the same district for a series of households.
 
 .. rubric:: XLSForm that shows using a last-saved value as a dynamic default
 
@@ -162,7 +162,7 @@ This can be very useful when an enumerator is expected to fill out the same  for
 
   text, street, Street, ${last-saved#street}
 
-The last saved instance can either be the last record that an enumerator started filling from a blank form or the last record that an enumerator opened to edit and then saved.
+The value is pulled from the last saved record. This is often the most recently created record but it could also be a previously-existing record that was edited and saved.
 
 .. _form-logic-gotchas:
 
@@ -264,7 +264,7 @@ without answering the question.
 Setting default responses
 ===========================
 
-To provide a default response to a question, put a value in the :th:`default` column. Defaults are set once when each instance of a form definition is first opened for filling and can then be changed by enumerators. Defaults can either be fixed values (:ref:`static defaults <static-defaults>`) or the result of some expression (:ref:`dynamic defaults <dynamic-defaults>`).
+To provide a default response to a question, put a value in the :th:`default` column. Defaults are set once when a record is first created from a form definition. Defaults can either be fixed values (:ref:`static defaults <static-defaults>`) or the result of some expression (:ref:`dynamic defaults <dynamic-defaults>`). 
 
 .. _static-defaults:
 
@@ -296,9 +296,9 @@ Dynamic defaults
 
 .. warning::
   
-  Support for :ref:`dynamic defaults <dynamic-defaults>` was added in Collect v1.24.0. Form conversion requires XLSForm Online ≥ v2.0.0 or pyxform ≥ v1.0.0.
+  Support for :ref:`dynamic defaults <dynamic-defaults>` was added in Collect v1.24.0. Form conversion requires XLSForm Online ≥ v2.0.0 or pyxform ≥ v1.0.0. Using older versions will have unpredictable results.
 
-If you put an expression in the :th:`default` column for a question, that expression will be evaluated once when a record is first created from a blank form definition. This allows you to use values from outside the form like the current date or the :ref:`server username <metadata>`.
+If you put an expression in the :th:`default` column for a question, that expression will be evaluated once when a record is first created from a blank form definition. This allows you to use values from outside the form like the current date or the :ref:`server username <metadata>`. Dynamic defaults can't be used to base the default value of one field on the value of another field in the form. For example, if you have an ``age`` question and you want to default the diagnosis age to the value of the ``age`` question, see :ref:`the tip below <defaults-from-form-data>`.
 
 .. rubric:: XLSForm to set the current date as default
 
@@ -317,7 +317,7 @@ In the example below, if a username is set either in the :ref:`server configurat
   username, username
   text, confirmed_username, What is your username?, ${username}
 
-If enumerators are creating records representing groups of things with the same property, dynamic defaults can be combined with :ref:`last saved <last-saved>`.
+If enumerators will need to enter the same value for multiple consecutive records, dynamic defaults can be combined with :ref:`last saved <last-saved>`.
 
 Dynamic defaults in repeats are evaluated when a new repeat instance is added.
 

--- a/odk1-src/form-logic.rst
+++ b/odk1-src/form-logic.rst
@@ -140,6 +140,30 @@ you must first use a :tc:`calculate` row and then a variable.
   | Tip (18%): $${tip_18}
   | Total: $${tip_18_total}",
 
+.. _last-saved:
+
+Values from the last saved record
+----------------------------------
+
+.. warning::
+
+  Support for last-saved was added in Collect v1.21.0. Form conversion requires XLSForm Online ≥ v2.0.0 or pyxform ≥ v1.0.0.
+
+You can refer to values from the last saved record by wrapping a question name in ``${last-saved#`` and ``}``:
+
+:tc:`${last-saved#question-name}`
+
+This can be very useful when an enumerator is expected to fill out the same  form definition for groups of things with the same property. For example, if an enumerator is walking through a town and collecting information about people including the street that they live on, the street name will be the same for several records in a row.
+
+.. rubric:: XLSForm that shows using a last-saved value as a dynamic default
+
+.. csv-table:: survey
+  :header: type, name, label, default
+
+  text, street, Street, ${last-saved#street}
+
+The last saved instance can either be the last record that an enumerator started filling from a blank form or the last record that an enumerator opened to edit and then saved.
+
 .. _form-logic-gotchas:
 
 Form logic gotchas
@@ -274,7 +298,7 @@ Dynamic defaults
   
   Support for :ref:`dynamic defaults <dynamic-defaults>` was added in Collect v1.24.0. Form conversion requires XLSForm Online ≥ v2.0.0 or pyxform ≥ v1.0.0.
 
-If you put an expression in the :th:`default` column for a question, that expression will be evaluated once when an instance of a form definition is first opened. This allows you to use values from outside the form like the current date or the :ref:`server username <metadata>`.
+If you put an expression in the :th:`default` column for a question, that expression will be evaluated once when a record is first created from a blank form definition. This allows you to use values from outside the form like the current date or the :ref:`server username <metadata>`.
 
 .. rubric:: XLSForm to set the current date as default
 
@@ -293,12 +317,14 @@ In the example below, if a username is set either in the :ref:`server configurat
   username, username
   text, confirmed_username, What is your username?, ${username}
 
+If enumerators are creating records representing groups of things with the same property, dynamic defaults can be combined with :ref:`last saved <last-saved>`.
+
 Dynamic defaults in repeats are evaluated when a new repeat instance is added.
 
 .. tip:: 
   :name: defaults-from-form-data
 
-  You may want to use a value filled out by the enumerator as a default for another question that the enumerator will later fill in. Dynamic defaults can't be used for this because they are evaluated once when a form definition is first loaded and before an enumerator fills in any data.
+  You may want to use a value filled out by the enumerator as a default for another question that the enumerator will later fill in. Dynamic defaults can't be used for this because they are evaluated once when a record is first created which is before an enumerator fills in any data.
   
   One option is to use the :th:`calculation` column and wrap your default value expression in a :func:`once` function.
   


### PR DESCRIPTION
Adds documentation for dynamic defaults and last-saved.

I decided to put the version requirements in warning blocks in this case because using dynamic defaults or last-saved with tools that don't support it will have unpredictable results.

I'd like to add a section about dynamic defaults in repeats but so far the examples I've come up with either require writing XPath expressions like `if(position(..) >= 1, /data/child_details[position() = position(current()/..) - 1]/child_school, '')` or suffer from the issue I described at https://github.com/XLSForm/pyxform/issues/182#issuecomment-583560793. There's also a bug I discovered at https://github.com/XLSForm/pyxform/issues/427. So I think we should come back to that.