### PR TITLE
Update references to the Collect root directory in preparation for the scoped storage migration

### DIFF
--- a/odk1-src/briefcase-using.rst
+++ b/odk1-src/briefcase-using.rst
@@ -56,9 +56,9 @@ Briefcase will ask for the directory on your computer where you have placed Coll
 
 1. Ensure all filled-in forms are finalized.
 
-    If you have incomplete forms that you cannot finalize before pulling into Briefcase, delete them. If you need to keep them, make a copy of :file:`/sdcard/odk` before deleting them, and restore it after you are finished.
+    If you have incomplete forms that you cannot finalize before pulling into Briefcase, delete them. If you need to keep them, make a copy of :ref:`your Collect directory <collect-directory>` before deleting them, and restore it after you are finished.
 
-2. Using your device, create a zip archive of the entire :file:`odk` directory with a file managing app such as `OI File Manager <https://play.google.com/store/apps/details?id=org.openintents.filemanager>`_.
+2. Using your device, create a zip archive of :ref:`your Collect directory <collect-directory>` with a file managing app such as `OI File Manager <https://play.google.com/store/apps/details?id=org.openintents.filemanager>`_.
 3. Transfer the zip file to your local hard drive via a USB cable. You can also use the Share feature in your file manager to transfer it to a third-party service like Google Drive then download it to your local hard drive.
 4. Once the zip file is on your local hard drive, unzip the file.
 
@@ -72,7 +72,7 @@ Briefcase will ask for the directory on your computer where you have placed Coll
 
   .. code-block:: console
 
-      $ adb pull /sdcard/odk/instances
+      $ adb pull <collect-directory>/instances
 
 .. _pull-form-definition:
 

--- a/odk1-src/collect-adb.rst
+++ b/odk1-src/collect-adb.rst
@@ -54,7 +54,7 @@ __ https://android.gadgethacks.com/how-to/android-basics-install-adb-fastboot-ma
 Managing forms with ADB
 ---------------------------
 
-Forms are stored on the device in  :file:`/sdcard/odk/forms/`.
+Form definitions are stored on the device in the :file:`forms` subdirectory of :ref:`your Collect directory <collect-directory>`.
 
 .. _loading-blank-forms-with-adb:
 
@@ -63,7 +63,7 @@ Loading blank forms
 
 .. code-block:: console
 
-  $ adb push local/path/to/form.xml /sdcard/odk/forms/form.xml
+  $ adb push local/path/to/form.xml <collect-directory>/forms/form.xml
 
 .. note::
 
@@ -78,18 +78,18 @@ Deleting forms
 
 .. code-block:: console
 
-  $ adb shell rm -d /sdcard/odk/forms/form.xml
+  $ adb shell rm -d <collect-directory>/forms/form.xml
 
 .. _downloading-forms:
 
 Downloading forms to your computer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To download a completed form or form instance from the computer:
+To download all filled records from a device:
 
 .. code-block:: console
 
-  $ adb pull /sdcard/odk/forms/form.xml
+  $ adb pull <collect-directory>/instances/*
 
   
 .. _adb-dev-tasks:
@@ -102,13 +102,13 @@ Developer tasks and troubleshooting with ADB
 Downloading Collect databases
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Collect stores settings and form state information
+Collect stores form definition and form record state information
 in a few SQLite databases, 
 which you can pull onto your local computer.
 
 .. code-block:: console
   
-  $  adb pull /sdcard/odk/metadata/*.db
+  $  adb pull <collect-directory>/metadata/*.db
   
 .. _saving-screenshot-with-adb:
 
@@ -175,7 +175,7 @@ use :command:`adb logcat` to capture log events during the crash.
 #. Type :kbd:`CTRL-C` to stop logging.
 
 You can then upload the :file:`logfile.txt` file to 
-a `Collect issue on GitHub <https://github.com/opendatakit/collect/issues>`_
+a `a support forum post <https://forum.opendatakit.org/c/support>`_
 or post in the |forum|.
 
 .. _bugreport:
@@ -196,3 +196,17 @@ along with information about the device's
 hardware, firmware, and operating system.
 
 .. seealso:: https://developer.android.com/studio/debug/bug-report.html
+
+.. _collect-directory:
+
+Identifying the Collect directory on your device
+-------------------------------------------------
+
+The ODK Collect directory on your device is:
+
+* :file:`/sdcard/odk` if you are running an ODK Collect version less than v1.26.0 or have a file migration banner on the main screen
+* :file:`/sdcard/Android/data/org.odk.collect.android/files` if you have ODK Collect version v1.26.0+ and don't have a file migration banner on the main screen
+
+Prior to ODK Collect v1.26.0, all Collect files were stored in the :file:`/sdcard/odk` directory. This directory was available to other applications to integrate with which can be very useful but can pose privacy risks.
+
+Starting August 2020, Google will no longer allow Android applications to read or write files directly to this folder. Instead, each application will only be able to write files to a special directory that only it has access to. You can read more about this change `on the forum <https://forum.opendatakit.org/t/odk-collect-v1-26-storage-migration/25268>`_.

--- a/odk1-src/collect-forms.rst
+++ b/odk1-src/collect-forms.rst
@@ -77,18 +77,18 @@ Loading forms directly
 Loading forms with ``adb``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can load forms directly from a computer to your device via USB, using :doc:`Android Debug Bridge <collect-adb>`.
+You can load forms directly from a computer to your device's :ref:`Collect directory <collect-directory>` via USB, using :doc:`Android Debug Bridge <collect-adb>`.
 
 .. code-block:: none
 
-  $ adb push path/to/form.xml /sdcard/odk/forms/form.xml
+  $ adb push path/to/form.xml <collect-directory>/forms/form.xml
 
 .. _loading-forms-from-device-storage:
 
 Loading forms from device storage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can also download forms to your device via a web browser, and move them to the :file:`odk/forms/` directory, using the device's file manager (:menuselection:`Settings -> Storage & USB -> Explore`).
+You can also download forms to your device via a web browser, and move them to the :file:`forms/` directory, using the device's file manager (:menuselection:`Settings -> Storage & USB -> Explore`).
 
 1. Go to the Settings menu (:guilabel:`⚙`) on your device and find :menuselection:`Storage & USB`
 
@@ -115,7 +115,7 @@ Media files should be placed in a folder labeled :file:`{form-name}-media`.
 
 - When using ODK Aggregate, the form upload prompt includes instructions to upload the :file:`-media` folder. The files are downloaded automatically when :ref:`fetching forms from Aggregate <in-app-get-blank-forms>`.
 - When using Google Drive, the :file:`-media` folder should be uploaded to the same location as the form. If you share forms with another user, you need to share the parent folder which contains a form and a folder with media files. Sharing both of them separately wouldn't be enough.
-- If :ref:`loading forms directly to your device <loading-forms-directly>`, the :file:`-media` folder needs to be placed in the :file:`sdcard/odk/forms` directory, alongside the form itself.
+- If :ref:`loading forms directly to your device <loading-forms-directly>`, the :file:`-media` folder needs to be placed in the :file:`forms` subdirectory of :ref:`your Collect directory <collect-directory>`, alongside the form itself.
 
 
 .. _editing-saved-forms:
@@ -236,4 +236,4 @@ You can delete :formstate:`Blank` forms as well as filled forms in any state (:f
 Deleting Forms with ``adb``
 -------------------------------
 
-You can also :ref:`delete form instances directly with <deleting-forms-with-adb>` :doc:`Android Debug Bridge <collect-adb>`. They are stored in :file:`sdcard/odk/instances`, with a directory for each instance.
+You can also :ref:`delete form instances directly with <deleting-forms-with-adb>` :doc:`Android Debug Bridge <collect-adb>`. They are stored in the :file:`instances` subdirectory of :ref:`your Collect directory <collect-directory>`, with a directory for each instance.

--- a/odk1-src/collect-offline-maps.rst
+++ b/odk1-src/collect-offline-maps.rst
@@ -32,7 +32,7 @@ For the reference layer, however, you can select a file on the device, and it wi
 Offline maps quick start
 -------------------------
 #. :ref:`Get or create your MBTiles file <getting-map-tiles>` with `TileMill <https://tilemill-project.github.io/tilemill/>`_ or other software.
-#. :ref:`Transfer tiles to devices <transferring-offline-tiles>`. The MBTiles file must be placed on your device in the :file:`/sdcard/odk/layers` folder, and the filename must end in `.mbtiles`.
+#. :ref:`Transfer tiles to devices <transferring-offline-tiles>`. The MBTiles file must be placed on your device in the :file:`layers` subdirectory of :ref:`your Collect directory <collect-directory>`, and the filename must end in `.mbtiles`.
 #. Select your offline layer in the :ref:`reference layer settings <reference-layer-settings>`.
 #. Open a :ref:`geopoint <geopoint-maps>`, :ref:`geotrace <geotrace-widget>`, or :ref:`geoshape <geoshape-widget>` question.
 #. While viewing the map, you can also select the offline layer using the button that looks like a stack of layers.
@@ -55,7 +55,7 @@ If you have existing geospatial data that is not in an MBTiles file, you may be 
 
 Transferring offline tilesets to devices
 -----------------------------------------
-MBTiles files must be manually transferred to Android devices to be available to Collect. Place the MBTiles files in the :file:`/sdcard/odk/layers` folder, and ensure their filenames end in `.mbtiles`.
+MBTiles files must be manually transferred to Android devices to be available to Collect. Place the MBTiles files in the :file:`layers` subdirectory of :ref:`your Collect directory <collect-directory>`, and ensure their filenames end in `.mbtiles`.
 
 To transfer files, you can upload them to an online service such as Google Drive, connect your device to a computer and transfer them via USB, or use :doc:`adb <collect-adb>`.
 
@@ -63,7 +63,7 @@ To transfer files, you can upload them to an online service such as Google Drive
 
 Selecting offline tilesets
 ---------------------------
-Once an MBTiles file has been transferred to the :file:`/sdcard/odk/layers` folder, it will be available for selection as a reference layer. A reference layer provides useful reference information for a data collector. A reference layer with no transparency acts like a basemap.
+Once an MBTiles file has been transferred to the :file:`layers` subdirectory of :ref:`your Collect directory <collect-directory>`, it will be available for selection as a reference layer. A reference layer provides useful reference information for a data collector. A reference layer with no transparency acts like a basemap.
 
 There are two ways to set the reference layer:
 

--- a/odk1-src/xlsform.rst
+++ b/odk1-src/xlsform.rst
@@ -59,8 +59,8 @@ The :command:`xls2xform` command can then be used:
   
 .. tip::
 
-  Use pyxform together with :doc:`adb <collect-adb>` to quickly convert an XLSForm and load it to a device. Once you have both tools installed, convert and push in a single line:
+  Use pyxform together with :doc:`adb <collect-adb>` to quickly convert an XLSForm and load it to :ref:`a device's Collect directory <collect-directory>`. Once you have both tools installed, convert and push in a single line:
   
   .. code-block:: console
   
-    $ xls2xform form-name.xlsx form-name.xml && adb push form-name.xml /sdcard/odk/forms/form-name.xml
+    $ xls2xform form-name.xlsx form-name.xml && adb push form-name.xml <collect-directory>/forms/form-name.xml


### PR DESCRIPTION
Users of Collect from the Play Store will need to move their files to a scoped directory by August 2020. The migration will start being available in Collect v1.26.0. This PR replaces all references to `/sdcard/odk/`.

I searched the `odk1-src` directory for `/sdcard` and `/odk` and made replacements as appropriate. I decided to leave the .settings file documentation alone because it will get removed by #1192.