### PR TITLE
Bump minimum recommended version for Docker

### DIFF
--- a/odkx-src/sync-endpoint.rst
+++ b/odkx-src/sync-endpoint.rst
@@ -27,7 +27,7 @@ ODK-X Sync Endpoint does not store user information in its own database, instead
 ODK-X Sync Endpoint prerequisites
 -----------------------------------
 
-You must have :program:`Docker 17.06.1` or newer, and be running in *Swarm Mode*.
+You must have :program:`Docker 18.09.2` or newer, and be running in *Swarm Mode*.
 Follow these links for detailed instructions on installing :program:`Docker` and enabling Swarm Mode.
 
   - `Docker <https://docs.docker.com/install/>`_


### PR DESCRIPTION
closes #1197 



#### What is included in this PR?
An update of the minimum recommended version of Docker for ODK Sync Endpoint.