### PR TITLE
Update MarkupSafe to fix build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ hypothesis==3.69.1
 imagesize==0.7.1
 Jinja2==2.10.1
 livereload==2.5.2
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 more-itertools==4.3.0
 olefile==0.46
 pathtools==0.1.2


### PR DESCRIPTION
A new version of `setuptools` was released that deprecates "Feature" which was used by MarkupSafe. See https://github.com/pypa/setuptools/issues/2017#issuecomment-596307305 and pallets/markupsafe#57.