### PR TITLE
Clarify loss of Location EXIF Data when choosing images

### DIFF
--- a/docs/form-question-types.rst
+++ b/docs/form-question-types.rst
@@ -1682,7 +1682,7 @@ Image widgets
   Image files can be very large. We recommend always including :ref:`a maximum image size in form design <scaling-down-images>`. Also, consider making test submissions to your server with the Internet conditions you expect when gathering data to make sure that you can send files of the size you expect.
 
 .. warning::
-  As of Android 13, Google introduced a new photo picker, backported to devices running Android 11 and 12. This new picker is automatically used when users click the ``Choose Image`` button. The picker enhances privacy by removing sensitive metadata, including GPS location, from selected images. If you rely on metadata like GPS location, please note that this data may no longer be available.
+  Sensitive metadata, such as GPS location, is typically no longer included in images selected via :guilabel:`Choose Image` on Android 11 and later.
 
 .. _default-image-widget:
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -48,7 +48,6 @@ AWS
 Azul
 backend
 Backends
-backported
 balancer
 Barcode
 barcode


### PR DESCRIPTION
closes #1851

#### What is included in this PR?
This PR adds a warning to clarify that sensitive EXIF data may not be accessible on newer Android devices.