### PR TITLE
Remove Kapa until frequent captcha challenges are resolved

### DIFF
--- a/docs/_templates/sidebar/search.html
+++ b/docs/_templates/sidebar/search.html
@@ -1,3 +1,0 @@
-<div class="sidebar-search-container">
-<button class="sidebar-search" id="custom-ask-ai-button">Ask AI</button>
-</div>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,7 +88,7 @@ html_css_files = [
     'css/custom.css',
 ]
 
-html_js_files = ["js/custom.js"]
+# html_js_files = ["js/custom.js"]
 
 html_theme_options = {
     'light_css_variables': {


### PR DESCRIPTION
As discussed on Slack, multiple core team members are seeing repeated captcha challenges when trying to use "Ask AI" or "Search" at [docs.getodk.org](http://docs.getodk.org). We've confirmed that this is the case in multiple countries, across multiple ISPs and when using Chrome rather than other less popular browsers.

#### What is included in this PR?

I've removed `search.html` so the default search is provided again. I couldn't find a way of providing a fallback based on captchas as the Kapa widget does not seem to offer an event around that (https://docs.kapa.ai/integrations/website-widget/javascript-api/events). Discussing this with Kapa support is probably the only way to resolve this and make it an option again.

#### What new issues will need to be opened because of this PR?

Potentially an issue to add Kapa back in based on discussion with their support?
