### PR TITLE
Kapa support says reCAPTCHA is now less strict

### DIFF
--- a/docs/_static/js/custom.js
+++ b/docs/_static/js/custom.js
@@ -13,7 +13,6 @@ document.addEventListener("DOMContentLoaded", function () {
   script.setAttribute("data-search-mode-default", false);
   script.setAttribute("data-search-include-source-names",'["Docs"]');
   script.setAttribute("data-modal-override-open-id", "custom-ask-ai-button");
-  script.setAttribute("data-bot-protection-mechanism", "hcaptcha");
   script.async = true;
   document.head.appendChild(script);
 });


### PR DESCRIPTION
Kapa support says reCAPTCHA is now less strict

> data-bot-protection-mechanism: Determines the captcha service on the widget that provides protection from bots and other abuse. Default is "recaptcha". To use a different captcha service, set to "hcaptcha".
> https://docs.kapa.ai/integrations/website-widget/configuration