### PR TITLE
Tweak formatting

### DIFF
--- a/docs/central-troubleshooting.rst
+++ b/docs/central-troubleshooting.rst
@@ -104,11 +104,11 @@ If you absolutely must upload files over 100 MB, you can change `client_max_body
   $ cd central
   $ docker compose stop
   $ nano files/nginx/odk.conf.template
-  <modify value for client_max_body_size>
+  <modify client_max_body_size value>
   $ nano server/lib/http/endpoint.js
-  <modify value for X-OpenRosa-Accept-Content-Length>
+  <modify X-OpenRosa-Accept-Content-Length value>
   $ nano server/test/unit/http/endpoint.js
-  <modify value for X-OpenRosa-Accept-Content-Length>
+  <modify X-OpenRosa-Accept-Content-Length value>
   $ docker build
   $ docker compose up -d
 


### PR DESCRIPTION
`for` is a keyword that is colored. makes the text distracting.

Before
<img width="536" height="238" alt="Screenshot 2025-10-28 at 13 41 09" src="https://github.com/user-attachments/assets/598b0fa0-b1c2-40ab-b1aa-55e845faecb9" />

After
<img width="744" height="222" alt="Screenshot 2025-10-28 at 13 40 21" src="https://github.com/user-attachments/assets/4e90c8d5-a0d8-4d92-8a59-5479650cc408" />
