### PR TITLE
Sentry: fix references to SENTRY_ORG_SUBDOMAIN env var

### DIFF
--- a/docs/central-install-digital-ocean.rst
+++ b/docs/central-install-digital-ocean.rst
@@ -972,7 +972,7 @@ If you wish to use your own Sentry instance to receive your own errors, take the
 
 #. Create an account on `Sentry <https://sentry.io>`_, and create a new ``nodejs`` project.
 #. The new project will generate a ``DSN`` in this format: ``https://SENTRY_KEY@SENTRY_ORG_SUBDOMAIN.ingest.sentry.io/SENTRY_PROJECT``.
-#. In ``.env``, set ``SENTRY_SUBDOMAIN``, ``SENTRY_KEY`` and ``SENTRY_PROJECT`` to the values from step 2.
+#. In ``.env``, set ``SENTRY_ORG_SUBDOMAIN``, ``SENTRY_KEY`` and ``SENTRY_PROJECT`` to the values from step 2.
 
    .. code-block:: bash
 

--- a/docs/central-upgrade.rst
+++ b/docs/central-upgrade.rst
@@ -597,9 +597,9 @@ If you are using your own Sentry instance, then you must complete one additional
 
 .. code-block:: bash
 
- "orgSubdomain": "SENTRY_ORGANIZATION_SUBDOMAIN",
+ "orgSubdomain": "SENTRY_ORG_SUBDOMAIN",
 
-Replace ``SENTRY_ORGANIZATION_SUBDOMAIN`` with your `Sentry organization subdomain <https://forum.sentry.io/t/organization-subdomains-in-dsns/9360>`_.
+Replace ``SENTRY_ORG_SUBDOMAIN`` with your `Sentry organization subdomain <https://forum.sentry.io/t/organization-subdomains-in-dsns/9360>`_.
 
 .. _central-upgrade-1.4:
 


### PR DESCRIPTION
Closes #2013

#### What is included in this PR?

Changes:

* `SENTRY_SUBDOMAIN` -> `SENTRY_ORG_SUBDOMAIN`
* `SENTRY_ORGANIZATION_SUBDOMAIN` -> `SENTRY_ORG_SUBDOMAIN`
