### PR TITLE
Add FairScan tip

### DIFF
--- a/docs/form-question-types.rst
+++ b/docs/form-question-types.rst
@@ -2326,6 +2326,10 @@ Uploads any file from the device to the form.
 
   .. _potentially dangerous file: https://support.symantec.com/en_US/article.INFO3768.html
 
+.. tip::
+
+    To scan paper documents and attach them to your form, we recommend `FairScan <https://play.google.com/store/apps/details?id=org.fairscan.app>`_. It's a high-quality document scanner that automatically crops and straightens scans, then attaches them to your form as a PDF. Use a `file` question type with an appearance of `ex:org.fairscan.app.action.SCAN_TO_PDF` to enable it. See `demo video <https://www.youtube.com/watch?v=pnKIJqLzA2Y>`_.
+
 .. image:: /img/form-question-types/file-upload-widget.*
   :alt: The file upload widget in Collect.
        The question label is "Select a file to upload."


### PR DESCRIPTION
Considered putting this as a tip in the external file section, but I instead put it right at the top where it's easiest to find (and thus most useful).

<img width="774" height="499" alt="Screenshot 2026-01-19 at 09 29 00" src="https://github.com/user-attachments/assets/26093a7e-b180-4024-82f8-258f58e4c89f" />
