### PR TITLE
Documentation fallout for the DB_* -> PG* env var switch for configuring the DB connection

### DIFF
--- a/docs/central-install-digital-ocean.rst
+++ b/docs/central-install-digital-ocean.rst
@@ -457,7 +457,7 @@ Using a Custom Database Server
 .. warning::
   Using PostgreSQL version 14 isn't strictly required, but we only test with and support PostgreSQL 14.
 
-  Using a database server that is not on your local network, may result in poor performance.
+  Using a database server that is not on your local network may result in poor performance.
 
 Central comes with a PostgreSQL v14.x database server to store your data, which Central will connect to by default.
 However, you may want to connect to and use a database that runs elsewhere, for instance, one provisioned by your organization.

--- a/docs/central-install-digital-ocean.rst
+++ b/docs/central-install-digital-ocean.rst
@@ -455,11 +455,27 @@ Using a Custom Database Server
 ------------------------------
 
 .. warning::
-  Using PostgreSQL 14 isn't strictly required, but we only test with and support PostgreSQL 14.
+  Using PostgreSQL version 14 isn't strictly required, but we only test with and support PostgreSQL 14.
 
-  Using a custom database server that is not on your local network, may result in poor performance.
+  Using a database server that is not on your local network, may result in poor performance.
 
-Central comes with a PostgreSQL v14.x database server to store your data. To use a custom PostgreSQL database server:
+Central comes with a PostgreSQL v14.x database server to store your data, which Central will connect to by default.
+However, you may want to connect to and use a database that runs elsewhere, for instance, one provisioned by your organization.
+
+
+Configuring access to an external PostgreSQL database
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+From Central 2026.1 onwards, you can use PostgreSQL's environment variables in your ``.env`` file to configure the connection — 
+please refer to the `PostgreSQL documentation <https://www.postgresql.org/docs/14/libpq-envars.html>`_ for this.
+
+.. warning::
+  In particular, if previously you have used such a custom database connection and had SSL configured with ``DB_SSL=true``,
+  you will need to replace that setting with ``PGSSLMODE=require`` as the ``DB_SSL`` variable is no longer supported.
+
+
+Creating and using a custom PostgreSQL database server
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 #. Connect to your database server.
 
@@ -500,10 +516,10 @@ Central comes with a PostgreSQL v14.x database server to store your data. To use
 
    .. code-block:: bash
 
-     DB_HOST=my-db-host
-     DB_USER=my-db-user
-     DB_PASSWORD=my-db-password
-     DB_NAME=my-db-name
+     PGHOST=my-db-host
+     PGUSER=my-db-user
+     PGPASSWORD=my-db-password
+     PGDATABASE=my-db-name
 
 #. Build and restart the service container.
 

--- a/docs/central-upgrade.rst
+++ b/docs/central-upgrade.rst
@@ -101,6 +101,16 @@ You'll be asked to confirm the removal of all dangling images. Agree by typing t
 Version-specific upgrade instructions
 --------------------------------------
 
+
+.. _central-upgrade-2026.1:
+
+Upgrading to Central v2026.1
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This version of Central has switched to using `PostgreSQL environment variables <https://www.postgresql.org/docs/14/libpq-envars.html>`_ for configuring the database connection.
+No action is required unless you have configured a custom database connection *and* used the ``DB_SSL=true`` setting for it. In that case, replace it with ``PGSSLMODE=require`` by editing your ``.env`` file.
+
+
 .. _central-upgrade-2025.4:
 
 Upgrading to Central v2025.4

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -322,6 +322,7 @@ odkenv
 offline
 online
 onscreen
+onwards
 onwuachi
 Onwuachi
 opencamera


### PR DESCRIPTION
addresses part of #2034


#### What is included in this PR?

Documentation updates reflecting the change to using `PG*` environment variables for configuring the database connection.

#### What is left to be done in the addressed issue?

All the other things we're tracking in #2034

#### What problems did you encounter?

I needed to subsection to keep things organized.