### PR TITLE
Stay on Sphinx 8 before we explicitly upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx<9.0
 sphinx-autobuild
 sphinxcontrib-spelling
 furo


### PR DESCRIPTION
`master` is currently not building because of an error with `sphinx-autodoc`:

> sphinx.errors.ExtensionError: Could not import extension sphinx_toolbox.collapse (exception: cannot import name 'logger' from 'sphinx.ext.autodoc' (/home/circleci/.local/lib/python3.11/site-packages/sphinx/ext/autodoc/__init__.py))

We currently don't have any requirements pinning in `requirements.txt` so on CI Sphinx was upgraded to 9.x which makes significant changes. Let's stay on 8 until we explicitly make the switch.