### PR TITLE
Make MCP discoverable in Kapa widget

### DIFF
--- a/docs/_static/js/custom.js
+++ b/docs/_static/js/custom.js
@@ -9,6 +9,8 @@ document.addEventListener("DOMContentLoaded", function () {
   script.setAttribute("data-modal-title-ask-ai", "Ask AI");
   script.setAttribute("data-modal-ask-ai-input-placeholder", "Ask a question");
   script.setAttribute("data-modal-override-open-id", "custom-ask-ai-button");
+  script.setAttribute("data-mcp-subdomain", "odk-docs");
+  script.setAttribute("data-mcp-server-name", "ODK Docs MCP");
   script.async = true;
   document.head.appendChild(script);
 });


### PR DESCRIPTION
According to https://www.kapa.ai/blog/build-an-mcp-server-with-kapa-ai, adding this
```
data-mcp-subdomain="your-subdomain"
data-mcp-server-name="Your Docs MCP"
```

Will get a chat widget showing the header dropdown menu for MCP connections when enabled.
<img width="1449" height="492" alt="image" src="https://github.com/user-attachments/assets/a13000a1-d74a-4325-882d-644719847552" />
