### PR TITLE
autobuild-docker: tighten network binding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ autobuild:
 .PHONY: autobuild-docker
 autobuild-docker:
 	docker build --tag odk-docs-autobuild . && \
-	docker run --publish 8000:8000 --volume ./docs:/docs:rw odk-docs-autobuild
+	docker run --publish 127.0.0.1:8000:8000 --volume ./docs:/docs:rw odk-docs-autobuild
 
 .PHONY: sort-spelling-wordlist
 sort-spelling-wordlist:


### PR DESCRIPTION
#### What is included in this PR?

Update to `autobuild-docker` `make` target to restrict network binding to localhost.

#### What new issues will need to be opened because of this PR?

None.

#### What is left to be done in the addressed issue?

Nothing.

#### What problems did you encounter?

None.