### PR TITLE
Less distracting framing

### DIFF
--- a/docs/central-upgrade.rst
+++ b/docs/central-upgrade.rst
@@ -36,7 +36,9 @@ Upgrade notes
 * :ref:`Central v0.9 <central-upgrade-0.9>`: configure firewall
 
 .. note::
-  To see your version, click on the question mark icon in the upper right section of your Central menu bar, then click :guilabel:`Version`. If you don't see the question mark, you can see the version by adding ``version.txt`` to the root URL (e.g., `demo.getodk.cloud/version.txt <https://demo.getodk.cloud/version.txt>`_). Note that starting in v2026.2.0, it is expected for the client version to start with `0000000000000000000000000000000000000000`.
+  To see your version, click on the question mark icon in the upper right section of your Central menu bar, then click :guilabel:`Version`. If you don't see the question mark, you can see the version by adding ``version.txt`` to the root URL (e.g., `demo.getodk.cloud/version.txt <https://demo.getodk.cloud/version.txt>`_). 
+
+  For v2026.2.0 and later, it is expected that the client version starts with 40 zeros.
 
 .. _central-upgrade-steps:
 


### PR DESCRIPTION
All the zeros really stood out in the original text and I found it distracting.

<img width="835" height="171" alt="Screenshot 2026-08-08 at 13 10 45" src="https://github.com/user-attachments/assets/c04c72b1-55c1-41f4-8987-e23c3b71e4e6" />
