### PR TITLE
Reduce repetition and improve sentence flow in Entities intro

### DIFF
--- a/docs/entities-intro.rst
+++ b/docs/entities-intro.rst
@@ -27,7 +27,7 @@ Concepts
 What are Entities?
 ------------------
 
-In the ODK context, an "Entity" can be thought of as a "thing". If your project involves things that need to be shared between forms and may change over time, you can represent them as Entities. You can use Entities to represent real things like trees, people, or cities. You can also represent more abstract things like tree visits, malaria cases, or city ratings as Entities.
+In ODK, an **Entity** can be thought of as a “thing.” If your project involves items that need to be shared across forms and may change over time, you can represent them as Entities. Entities can represent real-world things such as trees, people, or cities. They can also represent more abstract concepts, such as tree visits, malaria cases, or city ratings.
 
 Entities are organized in lists that group together Entities of the same type. You can think of Entity Lists as spreadsheets or databases that are shared across forms. Forms can create, read, and update Entities. You can also think of Entities as the nouns (trees) and the forms as the verbs (Register a tree).
 

--- a/docs/entities-intro.rst
+++ b/docs/entities-intro.rst
@@ -27,7 +27,7 @@ Concepts
 What are Entities?
 ------------------
 
-In ODK, an **Entity** can be thought of as a “thing.” If your project involves items that need to be shared across forms and may change over time, you can represent them as Entities. Entities can represent real-world things such as trees, people, or cities. They can also represent more abstract concepts, such as tree visits, malaria cases, or city ratings.
+In ODK, an **Entity** can be thought of as a "thing." If your project involves items that need to be shared across forms and may change over time, you can represent them as Entities. Entities can represent real-world things such as trees, people, or cities. They can also represent more abstract concepts, such as tree visits, malaria cases, or city ratings.
 
 Entities are organized in lists that group together Entities of the same type. You can think of Entity Lists as spreadsheets or databases that are shared across forms. Forms can create, read, and update Entities. You can also think of Entities as the nouns (trees) and the forms as the verbs (Register a tree).
 


### PR DESCRIPTION
Related to #96

In the `entities-intro/` page, the paragraph describing Entities has some repetition of the word “thing” and could have smoother sentence flow. This PR improves the wording while keeping the terminology consistent.

#### What is included in this PR?

* Reduced repetition of the word “thing”
* Improved sentence flow
* Kept Entity-related terminology consistent