### PR TITLE
Add reference geometry

### DIFF
--- a/docs/form-datasets.rst
+++ b/docs/form-datasets.rst
@@ -243,8 +243,8 @@ To get the total population across states with a population above a certain thre
 
 .. _form-datasets-using-geometry:
 
-Using geographical features from datasets
-------------------------------------------
+Using geometry from datasets
+-----------------------------
 
 .. _specify-select-geometry:
 
@@ -264,14 +264,19 @@ For the first three options, geometry values must be specified in :ref:`the ODK 
 
 To use a GeoJSON file, see the :ref:`GeoJSON section <selects-from-geojson>`.
 
+All data source types support :ref:`style properties <select-from-map-style>`.
+
 .. _geo-questions-reference-geometry:
 
 Reference geometry
 ~~~~~~~~~~~~~~~~~~~
 
-Any internal or external dataset can be used as reference for the :ref:`geoshape <geoshape-widget>`, :ref:`geotrace <geotrace-widget>`, :ref:`geopoint with map display <geopoint-maps>` or :ref:`geopoint with user placement <placement-map-widget>` question types. This is useful when you want to provide previously-captured data as context for new geometry to capture.
+Any dataset or repeat can be used to provide reference geometry for the :ref:`geoshape <geoshape-widget>`, :ref:`geotrace <geotrace-widget>`, :ref:`geopoint with map display <geopoint-maps>` or :ref:`geopoint with user placement <placement-map-widget>` question types. This is useful to provide previously-captured data as context for collecting new geometry.
 
-To specify a dataset to use as reference geometry for a geo question, use the ``parameters`` column of your XLSForm for that question. Add `reference-geometry=` followed by the name of your dataset without an extension. The dataset must have ``geometry`` defined as described for :ref:`select one from map <specify-select-geometry>`.
+.. image:: /img/form-datasets/reference-geometry.png
+  :class: device-screen-vertical
+
+To specify a dataset to use as reference geometry for a geo question, use the ``parameters`` column of your XLSForm for that question. Add ``reference-geometry=`` followed by the name of your dataset without an extension. For datasets, each item to display must have a geometry value in the ODK format, see the :ref:`select one from map <specify-select-geometry>` section above for details.
 
 For example, if a data collector needs to capture the boundaries of agricultural plots, you can save those plots in an Entity List and display existing plots on a map to help guide the collection of the new plots.
 
@@ -287,11 +292,25 @@ For example, if a data collector needs to capture the boundaries of agricultural
 
   plots,${plot_name}
 
-Reference geometry is displayed in purple and shapes are shaded in. Reference geometry can include a mix of points, lines and shapes that are all displayed together.
+By default, reference geometry is displayed in purple without vertex markers and shapes are shaded in. Reference geometry also respects :ref:`style properties <select-from-map-style>`. A dataset used as reference geometry can include a mix of points, lines and shapes that are all displayed together. Reference geometry cannot be interacted with.
+
+Like with selects, you can specify a ``choice_filter`` expression to limit the rows used as reference geometry. For example, you could filter by county, assigned enumerator, or priority level.
 
 Reference geometry from repeats
 """"""""""""""""""""""""""""""""
 
-Reference geometry can also be specified from a repeat which you can think of as a dataset that can change dynamically. For a repeat to be used as a source for reference geometry, each repeat instance must have a ``geometry`` field directly inside it. If the ``geometry`` field is missing, that repeat instance will be skipped.
+Reference geometry can also come from a repeat. You can think of a repeat as a dataset that changes dynamically as repeat instances are added or updated.
 
-For example, if a data collector needs to capture information on several geographical 
+To specify a repeat as a source for reference geometry, use the ``parameters`` column of the XLSForm for the question you want to provide reference for. Add ``reference-geometry=`` followed by a `${}` reference to your repeat. Each repeat instance with a ``geometry`` field in it will be mapped and others will be silently ignored.
+
+.. csv-table:: survey
+  :header: type,name,label,parameters
+
+  begin_repeat,plot,Plot,
+  text,plot_name,Plot name,
+  geoshape,geometry,Select new plot,reference-geometry=${plot}
+  end_repeat
+
+Like when using Entity Lists or choice lists as reference, you can specify a ``choice_filter`` expression based on the fields in the repeat.
+
+See a working example of using reference geometry with Entity Lists and repeats in `this XLSForm <https://docs.google.com/spreadsheets/d/1LOWyM0D9AxrTSb7vmGhsp2DgbwqTqpF_eLQvXviouMM/edit?gid=1068911091#gid=1068911091>`_.

--- a/docs/form-datasets.rst
+++ b/docs/form-datasets.rst
@@ -255,14 +255,14 @@ Any internal or external dataset can be used as a source for the :ref:`select on
 
 You can specify geometry for all choice sources:
 
-#. If you specify choices in the form using the **choices** tab, add a ``geometry`` column
-#. If you use an :ref:`external CSV file <selects-from-csv>` and use ``select_one_from_file``, add a ``geometry`` column
-#. If you use an :doc:`Entity List <entities-intro>` and use ``select_one_from_file``, add a ``geometry`` property
-#. Use a :ref:`GeoJSON attachment <selects-from-geojson>` and ``select_one_from_file``
+- If you specify choices in the form using the **choices** tab, add a ``geometry`` column
+- If you use an :ref:`external CSV file <selects-from-csv>` and use ``select_one_from_file``, add a ``geometry`` column
+- If you use an :doc:`Entity List <entities-intro>` and use ``select_one_from_file``, add a ``geometry`` property
+- Use a :ref:`GeoJSON attachment <selects-from-geojson>` and ``select_one_from_file``
 
-For the first three options, geometry values must be specified in :ref:`the ODK format <location-widgets>`. This makes it straightforward to use data previously collected by ODK as choices displayed on a map. You must make sure that the column containing the geometry to use for each choice has the name ``geometry``.
+For all options other than GeoJSON, geometry values must be specified in :ref:`the ODK format <location-widgets>`. This makes it straightforward to use data previously collected by ODK as choices displayed on a map. You must make sure that the column containing the geometry to use for each choice has the name ``geometry``.
 
-To use a GeoJSON file, see the :ref:`GeoJSON section <selects-from-geojson>`.
+For a GeoJSON attachment, see :ref:`uilding selects from GeoJSON files <selects-from-geojson>`.
 
 All data source types support :ref:`style properties <select-from-map-style>`.
 
@@ -292,9 +292,9 @@ For example, if a data collector needs to capture the boundaries of agricultural
 
   plots,${plot_name}
 
-By default, reference geometry is displayed in purple without vertex markers and shapes are shaded in. Reference geometry also respects :ref:`style properties <select-from-map-style>`. A dataset used as reference geometry can include a mix of points, lines and shapes that are all displayed together. Reference geometry cannot be interacted with.
+By default, reference geometry is displayed in purple without vertex markers and shapes are shaded in. You can customize how each feature is displayed using :ref:`style properties <select-from-map-style>`. A dataset used as reference geometry can include a mix of points, lines and shapes that are all displayed together. Reference geometry cannot be interacted with.
 
-Like with selects, you can specify a ``choice_filter`` expression to limit the rows used as reference geometry. For example, you could filter by county, assigned enumerator, or priority level.
+You can specify a :ref:`choice filter <cascading-selects>` expression to limit the rows used as reference geometry. For example, you could filter by county, assigned enumerator, or priority level.
 
 Reference geometry from repeats
 """"""""""""""""""""""""""""""""

--- a/docs/form-datasets.rst
+++ b/docs/form-datasets.rst
@@ -85,8 +85,6 @@ If you would like to use other properties as values or labels, you can specify t
 Building selects from GeoJSON files
 ------------------------------------
 
-*New in* `ODK Collect v2022.2.0 <https://github.com/getodk/collect/releases/tag/v2022.2.0>`_, `ODK Central v1.4.0 <https://forum.getodk.org/t/odk-central-v1-4/36886>`_; Polygons and lines in Collect v2023.1.0; Web Forms support in Central v2025.3
-
 GeoJSON files that follow `the GeoJSON spec <https://datatracker.ietf.org/doc/html/rfc7946>`_ can be used to populate select question choices using ``select_one_from_file``. Selects from GeoJSON may be styled as maps using the :ref:`map appearance <select-from-map>` but can also use any other :ref:`select appearance <select-appearances>`. In order to be used by a form, a GeoJSON file:
 
 - must have a ``.geojson`` extension (NOT ``.json``)
@@ -152,12 +150,32 @@ XML files used for selects must have the following structure and can have any nu
 
 The ``item`` blocks are analogous to rows in the CSV representation. Each ``item`` must have at least ``name`` and ``label`` nested nodes and can have any number of additional nodes. These nodes correspond to columns in the CSV representation.
 
+.. _form-datasets-attaching-csv:
+
+Attaching datasets without a select
+-----------------------------------
+
+If you want to use a CSV or Entity List directly without first going through a selection step, you can attach that CSV or Entity List with ``csv-external``:
+
+.. csv-table:: survey
+  :header: type,name,label,calculation
+
+  csv-external,people
+  barcode,person_id,Scan person's ID card
+  calculate,person_fname,,instance("people")/root/item[code=${person_id}]/fname
+
+The example form above attaches a CSV with filename ``people.csv`` or an :doc:`Entity List <central-entities>` named ``people``. It then prompts the user to scan a barcode from an ID card and uses the value from the ID card to look up the corresponding person's first name. If attaching an actual CSV file, it must have columns named ``fname`` and ``code``. Similarly, if using an entity list, that entity list must have properties named ``fname`` and ``code``.
+
+.. note::
+
+  To attach an XML file named ``people.xml`` instead, replace ``csv-external`` above with ``xml-external``.
+
 .. _referencing-values-in-datasets:
 
 Looking up values in datasets
----------------------------------
+------------------------------
 
-You can look up values from internal or external datasets. You can look up values and save them for analysis or use in other expressions by using a ``calculate``. You can also use lookup expressions directly in constraints and other expressions or use them directly in ``label``\s to display them to users.
+You can look up values from internal or external datasets. You can look up values and save them for analysis or use in other expressions by using a ``calculate``. You can also use lookup expressions directly in constraints and other expressions or in ``label``\s to display them to users.
 
 In the example below, a user is first prompted to select a participant from the list of people found in an external file. Then, the selected participant's ``name`` is used to look up the ``place`` that participant is assigned to. A second dataset is attached from a ``places.csv`` file using :ref:`csv-external <form-datasets-attaching-csv>`. The assigned place is looked up by ``name`` and its ``label`` is displayed directly in a **note**.
 
@@ -223,22 +241,57 @@ To get the total population across states with a population above a certain thre
 
 ``sum(instance("states")/root/item[population > ${pop_threshold}]/population)``
 
-.. _form-datasets-attaching-csv:
+.. _form-datasets-using-geometry:
 
-Attaching CSVs for lookups without a select
----------------------------------------------
+Using geographical features from datasets
+------------------------------------------
 
-If you want to look up a value in a CSV directly without first going through a selection step, you can attach that CSV with ``csv-external``:
+.. _specify-select-geometry:
+
+Select one from map
+~~~~~~~~~~~~~~~~~~~~
+
+Any internal or external dataset can be used as a source for the :ref:`select one from map <select-from-map>` question type.
+
+You can specify geometry for all choice sources:
+
+#. If you specify choices in the form using the **choices** tab, add a ``geometry`` column
+#. If you use an :ref:`external CSV file <selects-from-csv>` and use ``select_one_from_file``, add a ``geometry`` column
+#. If you use an :doc:`Entity List <entities-intro>` and use ``select_one_from_file``, add a ``geometry`` property
+#. Use a :ref:`GeoJSON attachment <selects-from-geojson>` and ``select_one_from_file``
+
+For the first three options, geometry values must be specified in :ref:`the ODK format <location-widgets>`. This makes it straightforward to use data previously collected by ODK as choices displayed on a map. You must make sure that the column containing the geometry to use for each choice has the name ``geometry``.
+
+To use a GeoJSON file, see the :ref:`GeoJSON section <selects-from-geojson>`.
+
+.. _geo-questions-reference-geometry:
+
+Reference geometry
+~~~~~~~~~~~~~~~~~~~
+
+Any internal or external dataset can be used as reference for the :ref:`geoshape <geoshape-widget>`, :ref:`geotrace <geotrace-widget>`, :ref:`geopoint with map display <geopoint-maps>` or :ref:`geopoint with user placement <placement-map-widget>` question types. This is useful when you want to provide previously-captured data as context for new geometry to capture.
+
+To specify a dataset to use as reference geometry for a geo question, use the ``parameters`` column of your XLSForm for that question. Add `reference-geometry=` followed by the name of your dataset without an extension. The dataset must have ``geometry`` defined as described for :ref:`select one from map <specify-select-geometry>`.
+
+For example, if a data collector needs to capture the boundaries of agricultural plots, you can save those plots in an Entity List and display existing plots on a map to help guide the collection of the new plots.
 
 .. csv-table:: survey
-  :header: type,name,label,calculation
+  :header: type,name,label,save_to,parameters
 
-  csv-external,people
-  barcode,person_id,Scan person's ID card
-  calculate,person_fname,,instance("people")/root/item[code=${person_id}]/fname
+  csv-external,plots
+  text,plot_name,Plot name,,
+  geoshape,outline,Select new plot,geometry,reference-geometry=plots
 
-The example form above attaches a CSV with filename ``people.csv`` or an :doc:`entity list <central-entities>` named ``people``. It then prompts the user to scan a barcode from an ID card and uses the value from the ID card to look up the corresponding person's first name. If attaching an actual CSV file, it must have columns named ``fname`` and ``code``. Similarly, if using an entity list, that entity list must have properties named ``fname`` and ``code``.
+.. csv-table:: entities
+  :header: list_name,label
 
-.. note::
+  plots,${plot_name}
 
-  To attach an XML file named ``people.xml`` instead, replace ``csv-external`` above with ``xml-external``.
+Reference geometry is displayed in purple and shapes are shaded in. Reference geometry can include a mix of points, lines and shapes that are all displayed together.
+
+Reference geometry from repeats
+""""""""""""""""""""""""""""""""
+
+Reference geometry can also be specified from a repeat which you can think of as a dataset that can change dynamically. For a repeat to be used as a source for reference geometry, each repeat instance must have a ``geometry`` field directly inside it. If the ``geometry`` field is missing, that repeat instance will be skipped.
+
+For example, if a data collector needs to capture information on several geographical 

--- a/docs/form-question-types.rst
+++ b/docs/form-question-types.rst
@@ -1168,7 +1168,7 @@ appearance
 .. warning::
   The `map` appearance for selects is available in Web Forms (added in Central v2025.3) but not in Enketo. See more about the available features of **select one from map** in Web Forms and best practices :ref:`here <web-forms-select-from-map>`.
 
- If Collect feels slow when creating the map or when selecting a choice, please describe what you are experiencing `on the forum <https://forum.getodk.org/c/support/6>`_. You can  use a :ref:`choice filter <cascading-selects>` to reduce the number of choices that get mapped.
+ If Collect feels slow when creating the map or when selecting a choice, please describe what you are experiencing `on the forum <https://forum.getodk.org/c/support/6>`_. You can use a :ref:`choice filter <cascading-selects>` to reduce the number of choices that get mapped.
 
 .. note::
     The only appearance that can combine with selection from map is `quick`.
@@ -1190,7 +1190,7 @@ When the map is first opened, it centers on the device's current location. There
 
 Point choices are represented by map markers (:fa:`map-marker`). Tapping on a marker increases its size.
 
-Line and polygon choices are represented by teal lines. The inside of polygons is shaded teal and can be tapped to select the polygon.
+Line and polygon choices are represented by teal lines. Polygons are filled with translucent teal and can be selected by tapping anywhere inside them.
 
 .. note::
     Choices with invalid geometries are silently ignored. There will be no message displayed to a user when it happens.
@@ -1555,7 +1555,7 @@ appearance
 
 .. seealso:: 
   
-  You can display other geometry on the map as :ref:`reference geometry <geo-questions-reference-geometry>`.
+  You can display previously collected geospatial data on the map as :ref:`reference geometry <geo-questions-reference-geometry>`.
 
 The default :ref:`geopoint-widget` does not display a map to the user. When the appearance attribute is ``maps``, the widget displays a map to help the user get oriented and confirm that the selected point is correct and sufficiently accurate.
 
@@ -1584,7 +1584,7 @@ appearance
 
 .. seealso:: 
   
-  You can display other geometry on the map as :ref:`reference geometry <geo-questions-reference-geometry>`.
+  You can display previously collected geospatial data on the map as :ref:`reference geometry <geo-questions-reference-geometry>`.
 
 The default :ref:`geopoint-widget` does not allow the user to place the point anywhere other than the device's current geolocation.
 
@@ -1617,7 +1617,7 @@ appearance
 
 .. seealso:: 
   
-  You can display other geometry on the map as :ref:`reference geometry <geo-questions-reference-geometry>`.
+ You can display previously collected geospatial data on the map as :ref:`reference geometry <geo-questions-reference-geometry>`.
 
 A series of points. Identical to :ref:`geoshape <geoshape-widget>` except that the first and last point may be different and at least 2 points are required.
 
@@ -1670,7 +1670,7 @@ appearance
 
 .. seealso:: 
   
-  You can display other geometry on the map as :ref:`reference geometry <geo-questions-reference-geometry>`.
+  You can display previously collected geospatial data on the map as :ref:`reference geometry <geo-questions-reference-geometry>`.
 
 A series of points that form a closed polygon. Identical to :ref:`geotrace <geotrace-widget>` except that the first and last point are always the same and at least 3 points are required.
 

--- a/docs/form-question-types.rst
+++ b/docs/form-question-types.rst
@@ -1160,12 +1160,6 @@ If adding images, note that the images are referenced in the choices sheet, and 
 Select one from map widget
 """""""""""""""""""""""""""
 
-.. versionadded:: 2023.1.0
-
-  `ODK Collect v2023.1.0 <https://github.com/getodk/collect/releases/tag/v2023.1.0>`_
-
-.. versionadded:: v2025.3 Web Forms in Central
-
 type
  ``select_one {list_name}``
 appearance
@@ -1174,7 +1168,7 @@ appearance
 .. warning::
   The `map` appearance for selects is available in Web Forms (added in Central v2025.3) but not in Enketo. See more about the available features of **select one from map** in Web Forms and best practices :ref:`here <web-forms-select-from-map>`.
 
-  The different :ref:`basemap sources <mapping-settings>` currently have different performance. If Collect feels slow when creating the map or when selecting a choice, please describe what you are experiencing `on the forum <https://forum.getodk.org/c/support/6>`_. If you have many choices to include on a map, try a provider other than Google or Mapbox. You can also use a :ref:`choice filter <cascading-selects>` to reduce the number of choices that get mapped.
+  The different :ref:`basemap sources <mapping-settings>` currently have different performance. If Collect feels slow when creating the map or when selecting a choice, please describe what you are experiencing `on the forum <https://forum.getodk.org/c/support/6>`_. You can  use a :ref:`choice filter <cascading-selects>` to reduce the number of choices that get mapped.
 
 .. note::
     The only appearance that can combine with selection from map is `quick`.
@@ -1189,23 +1183,6 @@ If the choices that you want users to select from are locations, you can display
   :alt: Single select from map as displayed in the ODK Collect app on an Android phone. The question text is "Select a building to inspect" and it is displayed in a small top bar. Below that is a map with several buildings outlined in red with red shading. At the bottom of the screen, there is information about the selected building. Its label is "Elephant Care Center". Below the properties, there is a rounded button with a save icon and the text "Select."
   :class: device-screen-vertical
 
-.. _specify-select-geometry:
-
-Specifying geometry for choices
-'''''''''''''''''''''''''''''''''''
-You can specify geometry for all choice sources:
-
-#. If you specify choices in the form using the **choices** tab, add a ``geometry`` column
-#. If you use an :ref:`external CSV file <selects-from-csv>` and use ``select_one_from_file``, add a ``geometry`` column
-#. Use a :ref:`GeoJSON attachment <selects-from-geojson>` and ``select_one_from_file``
-
-For the first two options, geometry values must be specified in :ref:`the ODK format <location-widgets>`. This makes it straightforward to use data previously collected by ODK as choices displayed on a map. You must make sure that the column containing the geometry to use for each choice has the name ``geometry``.
-
-Learn more about using GeoJSON attachments and see an example :ref:`here <selects-from-geojson>`.
-
-.. note::
-    Choices with invalid geometries are silently ignored. There will be no message displayed to a user when it happens.
-
 Select one from map behavior
 '''''''''''''''''''''''''''''
 
@@ -1213,7 +1190,10 @@ When the map is first opened, it centers on the device's current location. There
 
 Point choices are represented by map markers (:fa:`map-marker`). Tapping on a marker increases its size.
 
-Line and polygon choices are represented by red lines. The inside of polygons is shaded red and can be tapped to select the polygon.
+Line and polygon choices are represented by teal lines. The inside of polygons is shaded teal and can be tapped to select the polygon.
+
+.. note::
+    Choices with invalid geometries are silently ignored. There will be no message displayed to a user when it happens.
 
 When a choice is selected, its properties are displayed at the bottom of the screen. Those properties are from:
 
@@ -1226,6 +1206,9 @@ Choice properties
 ''''''''''''''''''
 
 All of a choice's properties including ``geometry`` can be used in the rest of the form (see :ref:`referencing values in datasets <referencing-values-in-datasets>`) including in :ref:`choice filter <cascading-selects>` expressions. Even if the choices are specified from a GeoJSON file, the ``geometry`` property is made available to the form in :ref:`the ODK format <location-widgets>`, NOT as GeoJSON.
+
+Style properties
+''''''''''''''''
 
 There are special properties that can be used to style different choices:
 

--- a/docs/form-question-types.rst
+++ b/docs/form-question-types.rst
@@ -1168,7 +1168,7 @@ appearance
 .. warning::
   The `map` appearance for selects is available in Web Forms (added in Central v2025.3) but not in Enketo. See more about the available features of **select one from map** in Web Forms and best practices :ref:`here <web-forms-select-from-map>`.
 
-  The different :ref:`basemap sources <mapping-settings>` currently have different performance. If Collect feels slow when creating the map or when selecting a choice, please describe what you are experiencing `on the forum <https://forum.getodk.org/c/support/6>`_. You can  use a :ref:`choice filter <cascading-selects>` to reduce the number of choices that get mapped.
+ If Collect feels slow when creating the map or when selecting a choice, please describe what you are experiencing `on the forum <https://forum.getodk.org/c/support/6>`_. You can  use a :ref:`choice filter <cascading-selects>` to reduce the number of choices that get mapped.
 
 .. note::
     The only appearance that can combine with selection from map is `quick`.
@@ -1206,6 +1206,9 @@ Choice properties
 ''''''''''''''''''
 
 All of a choice's properties including ``geometry`` can be used in the rest of the form (see :ref:`referencing values in datasets <referencing-values-in-datasets>`) including in :ref:`choice filter <cascading-selects>` expressions. Even if the choices are specified from a GeoJSON file, the ``geometry`` property is made available to the form in :ref:`the ODK format <location-widgets>`, NOT as GeoJSON.
+
+
+.. _select-from-map-style:
 
 Style properties
 ''''''''''''''''
@@ -1550,6 +1553,10 @@ type
 appearance
   ``maps``
 
+.. seealso:: 
+  
+  You can display other geometry on the map as :ref:`reference geometry <geo-questions-reference-geometry>`.
+
 The default :ref:`geopoint-widget` does not display a map to the user. When the appearance attribute is ``maps``, the widget displays a map to help the user get oriented and confirm that the selected point is correct and sufficiently accurate.
 
 When the device's geolocation is available, it is displayed on the map by a blue cross. A blue shaded circle around the cross represents the accuracy radius of the geolocation. The "add marker" button at the top right of the screen can be tapped to add a point at the location indicated by the middle of the blue cross. The selected point is represented by a small circle with a red outline.
@@ -1574,6 +1581,10 @@ type
   ``geopoint``
 appearance
   ``placement-map``
+
+.. seealso:: 
+  
+  You can display other geometry on the map as :ref:`reference geometry <geo-questions-reference-geometry>`.
 
 The default :ref:`geopoint-widget` does not allow the user to place the point anywhere other than the device's current geolocation.
 
@@ -1603,6 +1614,10 @@ type
   ``geotrace``
 appearance
   *none*
+
+.. seealso:: 
+  
+  You can display other geometry on the map as :ref:`reference geometry <geo-questions-reference-geometry>`.
 
 A series of points. Identical to :ref:`geoshape <geoshape-widget>` except that the first and last point may be different and at least 2 points are required.
 
@@ -1652,6 +1667,10 @@ type
   ``geoshape``
 appearance
   *none*
+
+.. seealso:: 
+  
+  You can display other geometry on the map as :ref:`reference geometry <geo-questions-reference-geometry>`.
 
 A series of points that form a closed polygon. Identical to :ref:`geotrace <geotrace-widget>` except that the first and last point are always the same and at least 3 points are required.
 

--- a/docs/img/form-datasets/reference-geometry.png
+++ b/docs/img/form-datasets/reference-geometry.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58b0050d0b6d7a83f8c8da9b03fe8aa256d4cf63321ef6967789d57d03a6b5db
+size 139357


### PR DESCRIPTION
Closes https://github.com/getodk/docs/issues/2071

I had a hard time picking where to put this! I feel like it might be helpful to have a guide on all things geo at some point. For now I put it in our section about secondary instances which we call datasets in user-facing docs. That makes it easy to reference the info on select one from map and explain how to structure the Entity Lists/attached files/choice lists.

