### PR TITLE
Remove unstable shortcut

### DIFF
--- a/docs/central-install-digital-ocean.rst
+++ b/docs/central-install-digital-ocean.rst
@@ -142,7 +142,7 @@ Getting and Setting Up Central
 
    .. code-block:: bash
 
-     $ git submodule update -i
+     $ git submodule update --init
 
 #. Update settings. First, copy the settings template file so you can edit it:
 

--- a/docs/central-upgrade.rst
+++ b/docs/central-upgrade.rst
@@ -69,7 +69,7 @@ Upgrade steps
 
 .. code-block:: bash
 
-  $ git submodule update -i
+  $ git submodule update --init
 
 4. **Build** from the latest code you just fetched. The ``pull`` option ensures all Docker images are up-to-date.
 
@@ -506,7 +506,7 @@ This is *critical infrastructure upgrade*. In particular, it upgrades the includ
    
           .. code-block:: bash
    
-             $ git submodule update -i
+             $ git submodule update --init
    
        #. **Check that you have enough disk space available.** If you are prompted for a password, enter the system superuser password (not a Central password). You will see a message about how much space is required and if you have enough free space to proceed.
    


### PR DESCRIPTION
Closes #2090 

ChatGPT says: -i was an undocumented shorthand for --init. Git 2.43’s shell implementation happened to accept it, but the newer command-line parser in Git 2.55 accepts only the documented spelling.