### PR TITLE
Bump Python version to reduce vulns

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/work
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.14
     steps:
       - checkout
       - run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Match python version to CI
-FROM python:3.11
+FROM python:3.14-slim
 
 RUN apt-get update && \
     apt-get install --yes pngquant python3-enchant && \


### PR DESCRIPTION
I verified that `make autobuild-docker` builds the docs with no errors.

I chose `slim` because it's smaller than the regular image. `alpine` is even smaller, but apt-get wasn't installed and I didn't think it was worth the effort to figure out why.